### PR TITLE
Add support for inventory value

### DIFF
--- a/pkg/jobs/ansible/job.go
+++ b/pkg/jobs/ansible/job.go
@@ -27,6 +27,7 @@ const PREHOOK = "prehook"
 const POSTHOOK = "posthook"
 const MPSUFFIX = "-worker"
 const ICSUFFIX = "-install-config"
+const ANSIBLEINVENTORY = "ansible.curator.open-cluster-management.io/inventory"
 
 var ansibleJobGVR = schema.GroupVersionResource{
 	Group: "tower.ansible.com", Version: "v1alpha1", Resource: "ansiblejobs"}
@@ -302,6 +303,10 @@ func RunAnsibleJob(
 		}
 	} else {
 		ansibleJob.Object["spec"].(map[string]interface{})["extra_vars"].(map[string]interface{})["install_config"] = mp
+	}
+
+	if curator.Annotations != nil && curator.Annotations[ANSIBLEINVENTORY] != "" {
+		ansibleJob.Object["spec"].(map[string]interface{})["inventory"] = curator.Annotations[ANSIBLEINVENTORY]
 	}
 
 	klog.V(0).Info("Creating AnsibleJob " + ansibleJob.GetName() + " in namespace " + namespace)

--- a/pkg/jobs/ansible/job.go
+++ b/pkg/jobs/ansible/job.go
@@ -307,6 +307,9 @@ func RunAnsibleJob(
 
 	if curator.Annotations != nil && curator.Annotations[ANSIBLEINVENTORY] != "" {
 		ansibleJob.Object["spec"].(map[string]interface{})["inventory"] = curator.Annotations[ANSIBLEINVENTORY]
+		ansibleJob.Object["spec"].(map[string]interface{})["extra_vars"].(map[string]interface{})["managedcluster_name"] = curator.Annotations[ANSIBLEINVENTORY]
+	} else {
+		ansibleJob.Object["spec"].(map[string]interface{})["extra_vars"].(map[string]interface{})["managedcluster_name"] = curator.Name
 	}
 
 	klog.V(0).Info("Creating AnsibleJob " + ansibleJob.GetName() + " in namespace " + namespace)

--- a/pkg/jobs/ansible/job_test.go
+++ b/pkg/jobs/ansible/job_test.go
@@ -558,7 +558,26 @@ func TestRunAnsibleJobWithInventory(t *testing.T) {
 	aJob, err := RunAnsibleJob(client, cc, POSTHOOK, cc.Spec.Install.Posthook[0], "toweraccess")
 	assert.Nil(t, err, "err is nil when job is started")
 	assert.Equal(t, "my-cluster01", aJob.Object["spec"].(map[string]interface{})["inventory"], "inventory should be my-cluster01")
-	t.Logf("Fake ansibleJob launched with name: %v", aJob.GetName())
+	assert.Equal(t, "my-cluster01", aJob.Object["spec"].(map[string]interface{})["extra_vars"].(map[string]interface{})["managedcluster_name"], "managedcluster_name should be my-cluster01")
+}
+
+func TestRunAnsibleJobWithoutInventory(t *testing.T) {
+
+	cc := getClusterCurator()
+
+	t.Logf("Test %v", POSTHOOK)
+	os.Setenv(EnvJobType, POSTHOOK)
+
+	s.AddKnownTypes(ajv1.SchemeBuilder.GroupVersion, &ajv1.AnsibleJob{})
+	s.AddKnownTypes(clustercuratorv1.SchemeBuilder.GroupVersion, &clustercuratorv1.ClusterCurator{})
+	s.AddKnownTypes(hivev1.SchemeBuilder.GroupVersion, &hivev1.ClusterDeployment{}, &hivev1.MachinePool{})
+	s.AddKnownTypes(corev1.SchemeGroupVersion, &corev1.Secret{})
+	client := clientfake.NewFakeClientWithScheme(s, cc, genClusterDeployment(), genMachinePool(), genInstallConfigSecret())
+
+	aJob, err := RunAnsibleJob(client, cc, POSTHOOK, cc.Spec.Install.Posthook[0], "toweraccess")
+	assert.Nil(t, err, "err is nil when job is started")
+	assert.Nil(t, aJob.Object["spec"].(map[string]interface{})["inventory"], "inventory should be nil")
+	assert.Equal(t, "my-cluster", aJob.Object["spec"].(map[string]interface{})["extra_vars"].(map[string]interface{})["managedcluster_name"], "managedcluster_name should be my-cluster01")
 }
 
 /*


### PR DESCRIPTION
Signed-off-by: Joshua Packer <jpacker@redhat.com>

## Problem Description
* We want to be able to define an inventory when running the AnsibleJob resource

## What it fixes
* Enables a customer using inventory that does not exactly match the ACM name of my cluster.

## Issue
* NA

## Test Coverage
coverage: 70.6% of statements
ok  	github.com/stolostron/cluster-curator-controller/pkg/jobs/ansible	15.039s	coverage: 70.6% of statements
