### PR TITLE
rollback golang to 1.18

### DIFF
--- a/Dockerfile.prow
+++ b/Dockerfile.prow
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/stolostron/builder:go1.19-linux as builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.18-linux as builder
 
 WORKDIR /go/src/github.com/stolostron/cluster-curator-controller
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/cluster-curator-controller
 
-go 1.19
+go 1.18
 
 require (
 	github.com/go-logr/logr v1.2.3


### PR DESCRIPTION
Related issue: https://github.com/stolostron/backlog/issues/26639
Signed-off-by: Yang Le <yangle@redhat.com>