### PR TITLE
If the hook type is Workflow or the job_tags and skip_tags are omitte…

### DIFF
--- a/pkg/jobs/ansible/job.go
+++ b/pkg/jobs/ansible/job.go
@@ -140,8 +140,6 @@ func getAnsibleJob(jobtype string, // pre or post
 			"spec": map[string]interface{}{
 				templateNameKey:     ansibleTemplateName,
 				"tower_auth_secret": secretRef,
-				"job_tags":          jobTags,
-				"skip_tags":         skipTags,
 			},
 		},
 	}
@@ -156,6 +154,16 @@ func getAnsibleJob(jobtype string, // pre or post
 	}
 
 	ansibleJob.Object["spec"].(map[string]interface{})["extra_vars"] = mapExtraVars
+
+	if hooktype != string(clustercuratorv1.HookTypeWorkflow) {
+		if jobTags != "" {
+			ansibleJob.Object["spec"].(map[string]interface{})["job_tags"] = jobTags
+		}
+
+		if skipTags != "" {
+			ansibleJob.Object["spec"].(map[string]interface{})["skip_tags"] = skipTags
+		}
+	}
 
 	return ansibleJob
 }


### PR DESCRIPTION
…d or empty then the generated AnsibleJob should omit the job_tags and skip_tags fields.

Signed-off-by: Mike Ng <ming@redhat.com>

For:
https://issues.redhat.com/browse/ACM-2339
https://issues.redhat.com/browse/ACM-2340

More context in:
https://coreos.slack.com/archives/C014LBVDHSR/p1670439775716349