### PR TITLE
Add leader election settings

### DIFF
--- a/deploy/controller/deployment.yaml
+++ b/deploy/controller/deployment.yaml
@@ -18,6 +18,9 @@ spec:
       - command:
         - "./manager"
         - "-enable-leader-election"
+        - "--leader-election-lease-duration=137s"
+        - "--leader-election-renew-deadline=107s"
+        - "--leader-election-retry-period=26s"
         image: registry.ci.openshift.org/stolostron/2.3:cluster-curator-controller
         env:
         - name: POD_NAME

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,10 +1,10 @@
 sonar.projectKey=open-cluster-management_cluster-curator-controller
 sonar.projectName=cluster-curator-controller
 sonar.sources=.
-sonar.exclusions=**/*_test.go,**/*_generated*.go,**/*_generated/**,**/vendor/**
+sonar.exclusions=**/*_test.go,**/*_generated*.go,**/*_generated/**,**/cmd/manager/**,**/vendor/**
 sonar.tests=.
 sonar.test.inclusions=**/*_test.go
-sonar.test.exclusions=**/*_generated*.go,**/*_generated/**,**/vendor/**,controllers/**,pkg/api/**
+sonar.test.exclusions=**/*_generated*.go,**/*_generated/**,**/vendor/**,**/cmd/manager/**,**/controllers/**,**/pkg/api/**
 sonar.go.tests.reportPaths=report.json
 sonar.go.coverage.reportPaths=coverage.out
 sonar.externalIssuesReportPaths=gosec.json


### PR DESCRIPTION
This PR adds the leader election settings with default values:
``` 
--leader-election-lease-duration=136s
--leader-election-renew-deadline=107s
--leader-election-retry-period=26s
```

Updates sonar properties to ignore the controllers `main.go`