### PR TITLE
ACM-6494 Initial ClusterCurator Hypershift support

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ For more details on job flow within our architecture see our [**swimlane chart**
 
 ### Hosted cluster provisioning example: _(KubeVirt)_
 
-  * When creating the `HostedCluster` and `NodePool` resource add the `spec.pausedUntil` field with value `true` to both resources. If using the HostedCluster CLI you can specify the flag `--pausedUntil true`.
+  * When creating the `HostedCluster` and `NodePool` resource add the `spec.pausedUntil` field with value `true` to both resources. If using the `hcp create cluster` CLI you can specify the flag `--pausedUntil true`.
 
     ```yaml
     apiVersion: hypershift.openshift.io/v1beta1

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License](https://img.shields.io/:license-apache-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
 
 ## What is cluster-curator-controller
-This project contains jobs and controllers for curating work around Cluster Provisioning. It is designed to extend the capabilities already present within Hive `ClusterDeployment` and Open Cluster Management `ManagedCluster` kinds.
+This project contains jobs and controllers for curating work around Cluster Provisioning. It is designed to extend the capabilities already present within Hive `ClusterDeployment` and Open Cluster Management `ManagedCluster` kinds. Hosted cluster support was added as well so now the controller also handles `HostedCluster` and `NodePool` kinds. The controller will automatically detect between Hive and Hosted clusters and will handle each type accordingly.
 
 ## Architecture
 The controller found here, monitors for `ClusterCurator` kind.  When new instances of the resource are created, this controller creates a Kubernetes Job (curator job) that runs: `pre-hook Ansible`, `activate-and-monitor` and `posthook Ansible`.  The Job can be overridden with your own job flow.
@@ -69,7 +69,7 @@ For more details on job flow within our architecture see our [**swimlane chart**
 
 ---
 
-- ### Cluster provisioning example: _(AWS)_
+- ### Hive cluster provisioning example: _(AWS)_
 
   * In the Red Hat Advanced Cluster Management console, create a NEW cluster. Before you press the button to create the button, flip the YAML switch.  Add the annotation `hive.openshift.io/reconcile-pause=true`, then press **Create**
 
@@ -133,6 +133,71 @@ For more details on job flow within our architecture see our [**swimlane chart**
   
     ```
 
+### Hosted cluster provisioning example: _(KubeVirt)_
+
+  * When creating the `HostedCluster` and `NodePool` resource add the `spec.pausedUntil` field with value `true` to both resources. If using the HostedCluster CLI you can specify the flag `--pausedUntil true`.
+
+    ```yaml
+    apiVersion: hypershift.openshift.io/v1beta1
+    kind: HostedCluster
+    metadata:
+      name: my-cluster
+      namespace: clusters
+    spec:
+      pausedUntil: 'true'
+    ...
+    ```
+
+    ```yaml
+    apiVersion: hypershift.openshift.io/v1beta1
+    kind: NodePool
+    metadata:
+      name: my-cluster-us-east-2
+      namespace: clusters
+    spec:
+      pausedUntil: 'true'
+    ...
+    ```
+
+  * The cluster will show in the console as Creating, but it is waiting for curation. If you will be using Ansible, create a secret in the same namespace as the `HostedCluster` resource. Here is a an example:
+
+    ```yaml
+    ---
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: toweraccess
+      namespace: HOSTED_CLUSTER_NAMESPACE
+    stringData:
+      host: https://my-tower-domain.io
+      token: ANSIBLE_TOKEN_FOR_admin  
+    ```
+
+  * Now create the ClusterCurator resource kind in the `HostedCluster` namespace. The ClusterCurator name is required to be the same as the `HostedCluster` name. This will begin curation of your cluster provisioning by removing the `spec.pausedUntil` field in all the `HostedCluster` and `NodePool` resources.
+    ```yaml
+    ---
+    apiVersion: cluster.open-cluster-management.io/v1beta1
+    kind: ClusterCurator
+    metadata:
+      name: HOSTED_CLUSTER_NAME
+      namespace: HOSTED_CLUSTER_NAMESPACE
+      labels:
+        open-cluster-management: curator
+    spec:
+      desiredCuration: install
+      install:
+        prehook:
+          - name: Demo Job Template
+            extra_vars:
+              variable1: something-interesting
+              variable2: 2
+          - name: Demo Job Template
+        posthook:
+          - name: Demo Job Template
+    ```
+  Note: The `desiredCuration` commands are exactly the same as the Hive cluster since the controller will auto-detect the cluster type
+
+  * To monitor the status of the provision you can look at either the `ClusterCurator` status or look at the job logs from the `HostedCluster` namespace.
 ---
 
 - ### Diagnostic steps:

--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ For more details on job flow within our architecture see our [**swimlane chart**
           - name: Demo Job Template
         posthook:
           - name: Demo Job Template
+        towerAuthSecret: toweraccess
     ```
   Note: The `desiredCuration` commands are exactly the same as the Hive cluster since the controller will auto-detect the cluster type
 

--- a/cmd/curator/curator.go
+++ b/cmd/curator/curator.go
@@ -49,6 +49,13 @@ func main() {
 		clusterName = string(data)
 	}
 
+	clusterNamespace := clusterName
+	// Hypershift clusters name != namespace
+	// The code in main sets clusterName = namespace but this doesn't work for Hypershift
+	if len(os.Args) == 3 {
+		clusterName = os.Args[2]
+	}
+
 	// Build a connection to the Hub OCP
 	config, err := config.LoadConfig("", "", "")
 	utils.CheckError(err)
@@ -56,10 +63,10 @@ func main() {
 	client, err := utils.GetClient()
 	utils.CheckError(err)
 
-	curatorRun(config, client, clusterName)
+	curatorRun(config, client, clusterName, clusterNamespace)
 }
 
-func curatorRun(config *rest.Config, client clientv1.Client, clusterName string) {
+func curatorRun(config *rest.Config, client clientv1.Client, clusterName string, clusterNamespace string) {
 
 	var err error
 	var cmdErrorMsg = errors.New("Invalid Parameter: \"" + os.Args[1] +
@@ -81,12 +88,6 @@ func curatorRun(config *rest.Config, client clientv1.Client, clusterName string)
 		utils.CheckError(cmdErrorMsg)
 	}
 	jobChoice := os.Args[1]
-	clusterNamespace := clusterName
-	// Hypershift clusters name != namespace
-	// The code in main sets clusterName = namespace but this doesn't work for Hypershift
-	if len(os.Args) == 3 {
-		clusterName = os.Args[2]
-	}
 
 	providerCredentialPath := os.Getenv("PROVIDER_CREDENTIAL_PATH")
 

--- a/cmd/curator/curator_test.go
+++ b/cmd/curator/curator_test.go
@@ -140,7 +140,7 @@ func TestCuratorRunNoParam(t *testing.T) {
 
 	os.Args[1] = ""
 
-	curatorRun(nil, nil, ClusterName)
+	curatorRun(nil, nil, ClusterName, ClusterName)
 }
 
 func TestCuratorRunWrongParam(t *testing.T) {
@@ -158,7 +158,7 @@ func TestCuratorRunWrongParam(t *testing.T) {
 
 	os.Args[1] = "something-wrong"
 
-	curatorRun(nil, nil, ClusterName)
+	curatorRun(nil, nil, ClusterName, ClusterName)
 }
 
 func TestCuratorRunNoClusterCurator(t *testing.T) {
@@ -180,7 +180,7 @@ func TestCuratorRunNoClusterCurator(t *testing.T) {
 
 	os.Args[1] = "SKIP_ALL_TESTING"
 
-	curatorRun(nil, client, ClusterName)
+	curatorRun(nil, client, ClusterName, ClusterName)
 }
 
 func TestCuratorRunClusterCurator(t *testing.T) {
@@ -192,7 +192,7 @@ func TestCuratorRunClusterCurator(t *testing.T) {
 
 	os.Args[1] = "SKIP_ALL_TESTING"
 
-	assert.NotPanics(t, func() { curatorRun(nil, client, ClusterName) }, "no panic when ClusterCurator found and skip test")
+	assert.NotPanics(t, func() { curatorRun(nil, client, ClusterName, ClusterName) }, "no panic when ClusterCurator found and skip test")
 }
 
 func TestCuratorRunClusterCuratorInstallUpgradeOperation(t *testing.T) {
@@ -202,11 +202,11 @@ func TestCuratorRunClusterCuratorInstallUpgradeOperation(t *testing.T) {
 
 	os.Args[1] = "SKIP_ALL_TESTING"
 
-	assert.NotPanics(t, func() { curatorRun(nil, client, ClusterName) }, "no panic when ClusterCurator found and skip test")
+	assert.NotPanics(t, func() { curatorRun(nil, client, ClusterName, ClusterName) }, "no panic when ClusterCurator found and skip test")
 
 	client = clientfake.NewFakeClientWithScheme(s, getClusterCuratorWithUpgradeOperation())
 
-	assert.NotPanics(t, func() { curatorRun(nil, client, ClusterName) }, "no panic when ClusterCurator found and skip test")
+	assert.NotPanics(t, func() { curatorRun(nil, client, ClusterName, ClusterName) }, "no panic when ClusterCurator found and skip test")
 }
 
 func TestCuratorRunNoProviderCredentialPath(t *testing.T) {
@@ -228,7 +228,7 @@ func TestCuratorRunNoProviderCredentialPath(t *testing.T) {
 
 	os.Args[1] = "applycloudprovider-ansible"
 
-	curatorRun(nil, client, ClusterName)
+	curatorRun(nil, client, ClusterName, ClusterName)
 }
 
 func TestCuratorRunProviderCredentialPathEnv(t *testing.T) {
@@ -248,7 +248,7 @@ func TestCuratorRunProviderCredentialPathEnv(t *testing.T) {
 
 	os.Args[1] = "applycloudprovider-ansible"
 
-	curatorRun(nil, client, ClusterName)
+	curatorRun(nil, client, ClusterName, ClusterName)
 }
 
 func TestInvokeMonitor(t *testing.T) {
@@ -261,7 +261,7 @@ func TestInvokeMonitor(t *testing.T) {
 	os.Setenv("PROVIDER_CREDENTIAL_PATH", "namespace/secretname")
 	os.Args[1] = "monitor"
 
-	curatorRun(nil, clientfake.NewFakeClient(), ClusterName)
+	curatorRun(nil, clientfake.NewFakeClient(), ClusterName, ClusterName)
 }
 
 func TestInvokeMonitorImport(t *testing.T) {
@@ -274,7 +274,7 @@ func TestInvokeMonitorImport(t *testing.T) {
 	os.Setenv("PROVIDER_CREDENTIAL_PATH", "namespace/secretname")
 	os.Args[1] = "monitor-import"
 
-	curatorRun(nil, clientfake.NewFakeClient(), ClusterName)
+	curatorRun(nil, clientfake.NewFakeClient(), ClusterName, ClusterName)
 }
 
 func TestInvokeMonitorDestroy(t *testing.T) {
@@ -287,7 +287,7 @@ func TestInvokeMonitorDestroy(t *testing.T) {
 	os.Setenv("PROVIDER_CREDENTIAL_PATH", "namespace/secretname")
 	os.Args[1] = "monitor-destroy"
 
-	curatorRun(nil, clientfake.NewFakeClient(), ClusterName)
+	curatorRun(nil, clientfake.NewFakeClient(), ClusterName, ClusterName)
 }
 
 func TestUpgradFailed(t *testing.T) {
@@ -315,7 +315,7 @@ func TestUpgradFailed(t *testing.T) {
 		},
 	})
 
-	curatorRun(nil, client, ClusterName)
+	curatorRun(nil, client, ClusterName, ClusterName)
 }
 
 func TestUpgradDone(t *testing.T) {
@@ -343,7 +343,7 @@ func TestUpgradDone(t *testing.T) {
 		},
 	})
 
-	curatorRun(nil, client, ClusterName)
+	curatorRun(nil, client, ClusterName, ClusterName)
 }
 
 func TestHypershiftActivate(t *testing.T) {
@@ -367,7 +367,7 @@ func TestHypershiftActivate(t *testing.T) {
 
 	config, _ := config.LoadConfig("", "", "")
 
-	curatorRun(config, client, ClusterNamespace)
+	curatorRun(config, client, ClusterNamespace, ClusterName)
 }
 
 func TestHypershiftMonitor(t *testing.T) {
@@ -391,7 +391,7 @@ func TestHypershiftMonitor(t *testing.T) {
 
 	config, _ := config.LoadConfig("", "", "")
 
-	curatorRun(config, client, ClusterNamespace)
+	curatorRun(config, client, ClusterNamespace, ClusterName)
 }
 
 func TestHypershiftDestroyCluster(t *testing.T) {
@@ -415,7 +415,7 @@ func TestHypershiftDestroyCluster(t *testing.T) {
 
 	config, _ := config.LoadConfig("", "", "")
 
-	curatorRun(config, client, ClusterNamespace)
+	curatorRun(config, client, ClusterNamespace, ClusterName)
 }
 
 func TestHypershiftMonitorDestroy(t *testing.T) {
@@ -439,7 +439,7 @@ func TestHypershiftMonitorDestroy(t *testing.T) {
 
 	config, _ := config.LoadConfig("", "", "")
 
-	curatorRun(config, client, ClusterNamespace)
+	curatorRun(config, client, ClusterNamespace, ClusterName)
 }
 
 func TestHypershiftUpgradeCluster(t *testing.T) {
@@ -463,7 +463,7 @@ func TestHypershiftUpgradeCluster(t *testing.T) {
 
 	config, _ := config.LoadConfig("", "", "")
 
-	curatorRun(config, client, ClusterNamespace)
+	curatorRun(config, client, ClusterNamespace, ClusterName)
 }
 
 func TestHypershiftMonitorUpgrade(t *testing.T) {
@@ -487,5 +487,5 @@ func TestHypershiftMonitorUpgrade(t *testing.T) {
 
 	config, _ := config.LoadConfig("", "", "")
 
-	curatorRun(config, client, ClusterNamespace)
+	curatorRun(config, client, ClusterNamespace, ClusterName)
 }

--- a/controllers/clustercurator_controller.go
+++ b/controllers/clustercurator_controller.go
@@ -100,6 +100,8 @@ func (r *ClusterCuratorReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 				return ctrl.Result{}, err
 			}
 			log.V(0).Info(" Created cluster namespace ✓")
+		} else if err != nil {
+			return ctrl.Result{}, err
 		}
 
 		err = rbac.ApplyRBACHypershift(r.Kubeset, curator.Name, curator.Namespace)

--- a/controllers/clustercurator_controller.go
+++ b/controllers/clustercurator_controller.go
@@ -89,7 +89,8 @@ func (r *ClusterCuratorReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	// Hypershift clusters need additional RBAC
 	if curator.Name != curator.Namespace {
 		log.V(2).Info("Check if cluster namespace " + curator.Name + " exists")
-		if _, err := r.Kubeset.CoreV1().Namespaces().Get(context.TODO(), curator.Name, v1.GetOptions{}); k8serrors.IsNotFound(err) {
+		if _, err := r.Kubeset.CoreV1().Namespaces().Get(
+			context.TODO(), curator.Name, v1.GetOptions{}); k8serrors.IsNotFound(err) {
 			log.V(2).Info("Creating cluster namespace " + curator.Name)
 			clusterNS := &corev1.Namespace{
 				ObjectMeta: v1.ObjectMeta{Name: curator.Name},

--- a/controllers/clustercurator_controller.go
+++ b/controllers/clustercurator_controller.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 
 	"github.com/go-logr/logr"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -18,6 +19,7 @@ import (
 	"github.com/stolostron/cluster-curator-controller/pkg/controller/launcher"
 	"github.com/stolostron/cluster-curator-controller/pkg/jobs/rbac"
 	"github.com/stolostron/cluster-curator-controller/pkg/jobs/utils"
+	corev1 "k8s.io/api/core/v1"
 )
 
 const DeleteNamespace = "delete-cluster-namespace"
@@ -81,6 +83,27 @@ func (r *ClusterCuratorReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	err := rbac.ApplyRBAC(r.Kubeset, req.Namespace)
 	if err := utils.LogError(err); err != nil {
 		return ctrl.Result{}, err
+	}
+
+	// Hypershift clusters need additional RBAC
+	if curator.Name != curator.Namespace {
+		log.V(2).Info("Check if cluster namespace " + curator.Name + " exists")
+		if _, err := r.Kubeset.CoreV1().Namespaces().Get(context.TODO(), curator.Name, v1.GetOptions{}); err != nil {
+			log.V(2).Info("Creating cluster namespace " + curator.Name)
+			clusterNS := &corev1.Namespace{
+				ObjectMeta: v1.ObjectMeta{Name: curator.Name},
+			}
+			_, err = r.Kubeset.CoreV1().Namespaces().Create(context.TODO(), clusterNS, v1.CreateOptions{})
+			if err := utils.LogError(err); err != nil {
+				return ctrl.Result{}, err
+			}
+			log.V(0).Info(" Created cluster namespace ✓")
+		}
+
+		err = rbac.ApplyRBACHypershift(r.Kubeset, curator.Name, curator.Namespace)
+		if err := utils.LogError(err); err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 
 	// Launch the curation job

--- a/controllers/clustercurator_controller.go
+++ b/controllers/clustercurator_controller.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stolostron/cluster-curator-controller/pkg/jobs/rbac"
 	"github.com/stolostron/cluster-curator-controller/pkg/jobs/utils"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 const DeleteNamespace = "delete-cluster-namespace"
@@ -88,7 +89,7 @@ func (r *ClusterCuratorReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	// Hypershift clusters need additional RBAC
 	if curator.Name != curator.Namespace {
 		log.V(2).Info("Check if cluster namespace " + curator.Name + " exists")
-		if _, err := r.Kubeset.CoreV1().Namespaces().Get(context.TODO(), curator.Name, v1.GetOptions{}); err != nil {
+		if _, err := r.Kubeset.CoreV1().Namespaces().Get(context.TODO(), curator.Name, v1.GetOptions{}); k8serrors.IsNotFound(err) {
 			log.V(2).Info("Creating cluster namespace " + curator.Name)
 			clusterNS := &corev1.Namespace{
 				ObjectMeta: v1.ObjectMeta{Name: curator.Name},

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ After you make your changes you actually need to build your own image because wh
 1. export REPO_URL=<your_quay_url> ie. quay.io/<user_name>
 2. export VERSION=<image_tag>
 3. make build-curator
-4. docker push <REPO_URL>/cluster-curator-controller:<VERSION>
+4. docker push <REPO_URL>/cluster-curator-controller:\<VERSION>
 
 ## Debugging locally in VSCode
 

--- a/pkg/controller/launcher/job.go
+++ b/pkg/controller/launcher/job.go
@@ -53,7 +53,7 @@ func NewLauncher(
 	}
 }
 
-func getBatchJob(clusterName string, imageURI string, curator clustercuratorv1.ClusterCurator) *batchv1.Job {
+func getBatchJob(clusterName string, clusterNamespace string, imageURI string, curator clustercuratorv1.ClusterCurator) *batchv1.Job {
 
 	var ttlf int32 = 3600
 
@@ -87,7 +87,7 @@ func getBatchJob(clusterName string, imageURI string, curator clustercuratorv1.C
 		newJob = &batchv1.Job{
 			ObjectMeta: v1.ObjectMeta{
 				GenerateName: "curator-job-",
-				Namespace:    clusterName,
+				Namespace:    clusterNamespace,
 				Labels: map[string]string{
 					"open-cluster-management": "curator-job",
 				},
@@ -108,14 +108,14 @@ func getBatchJob(clusterName string, imageURI string, curator clustercuratorv1.C
 							corev1.Container{
 								Name:            ActivateAndMonitor,
 								Image:           imageURI,
-								Command:         append([]string{CurCmd, ActivateAndMonitor}),
+								Command:         append([]string{CurCmd, ActivateAndMonitor, clusterName}),
 								ImagePullPolicy: corev1.PullAlways,
 								Resources:       resourceSettings,
 							},
 							corev1.Container{
 								Name:            MonImport,
 								Image:           imageURI,
-								Command:         append([]string{CurCmd, MonImport}),
+								Command:         append([]string{CurCmd, MonImport, clusterName}),
 								ImagePullPolicy: corev1.PullAlways,
 								Resources:       resourceSettings,
 							},
@@ -124,7 +124,7 @@ func getBatchJob(clusterName string, imageURI string, curator clustercuratorv1.C
 							corev1.Container{
 								Name:    DoneDoneDone,
 								Image:   imageURI,
-								Command: append([]string{CurCmd, DoneDoneDone}),
+								Command: append([]string{CurCmd, DoneDoneDone, clusterName}),
 							},
 						},
 					},
@@ -145,7 +145,7 @@ func getBatchJob(clusterName string, imageURI string, curator clustercuratorv1.C
 		newJob = &batchv1.Job{
 			ObjectMeta: v1.ObjectMeta{
 				GenerateName: "curator-job-",
-				Namespace:    clusterName,
+				Namespace:    clusterNamespace,
 				Labels: map[string]string{
 					"open-cluster-management": "curator-job",
 				},
@@ -166,14 +166,14 @@ func getBatchJob(clusterName string, imageURI string, curator clustercuratorv1.C
 							corev1.Container{
 								Name:            UpgradeCluster,
 								Image:           imageURI,
-								Command:         append([]string{CurCmd, UpgradeCluster}),
+								Command:         append([]string{CurCmd, UpgradeCluster, clusterName}),
 								ImagePullPolicy: corev1.PullAlways,
 								Resources:       resourceSettings,
 							},
 							corev1.Container{
 								Name:            MonUpgrade,
 								Image:           imageURI,
-								Command:         append([]string{CurCmd, MonUpgrade}),
+								Command:         append([]string{CurCmd, MonUpgrade, clusterName}),
 								ImagePullPolicy: corev1.PullAlways,
 								Resources:       resourceSettings,
 							},
@@ -182,7 +182,7 @@ func getBatchJob(clusterName string, imageURI string, curator clustercuratorv1.C
 							corev1.Container{
 								Name:    DoneDoneDone,
 								Image:   imageURI,
-								Command: append([]string{CurCmd, DoneDoneDone}),
+								Command: append([]string{CurCmd, DoneDoneDone, clusterName}),
 							},
 						},
 					},
@@ -199,7 +199,7 @@ func getBatchJob(clusterName string, imageURI string, curator clustercuratorv1.C
 		newJob = &batchv1.Job{
 			ObjectMeta: v1.ObjectMeta{
 				GenerateName: "curator-job-",
-				Namespace:    clusterName,
+				Namespace:    clusterNamespace,
 				Labels: map[string]string{
 					"open-cluster-management": "curator-job",
 				},
@@ -220,14 +220,14 @@ func getBatchJob(clusterName string, imageURI string, curator clustercuratorv1.C
 							corev1.Container{
 								Name:            DeleteClusterDeployment,
 								Image:           imageURI,
-								Command:         append([]string{CurCmd, DeleteClusterDeployment}),
+								Command:         append([]string{CurCmd, DeleteClusterDeployment, clusterName}),
 								ImagePullPolicy: corev1.PullIfNotPresent,
 								Resources:       resourceSettings,
 							},
 							corev1.Container{
 								Name:            MonitorDestroy,
 								Image:           imageURI,
-								Command:         append([]string{CurCmd, MonitorDestroy}),
+								Command:         append([]string{CurCmd, MonitorDestroy, clusterName}),
 								ImagePullPolicy: corev1.PullIfNotPresent,
 								Resources:       resourceSettings,
 							},
@@ -236,7 +236,7 @@ func getBatchJob(clusterName string, imageURI string, curator clustercuratorv1.C
 							corev1.Container{
 								Name:    DoneDoneDone,
 								Image:   imageURI,
-								Command: append([]string{CurCmd, DoneDoneDone}),
+								Command: append([]string{CurCmd, DoneDoneDone, clusterName}),
 							},
 						},
 					},
@@ -250,7 +250,7 @@ func getBatchJob(clusterName string, imageURI string, curator clustercuratorv1.C
 		newJob = &batchv1.Job{
 			ObjectMeta: v1.ObjectMeta{
 				GenerateName: "curator-job-",
-				Namespace:    clusterName,
+				Namespace:    clusterNamespace,
 				Labels: map[string]string{
 					"open-cluster-management": "curator-job",
 				},
@@ -271,7 +271,7 @@ func getBatchJob(clusterName string, imageURI string, curator clustercuratorv1.C
 							corev1.Container{
 								Name:    DoneDoneDone,
 								Image:   imageURI,
-								Command: append([]string{CurCmd, DoneDoneDone}),
+								Command: append([]string{CurCmd, DoneDoneDone, clusterName}),
 							},
 						},
 					},
@@ -286,7 +286,7 @@ func getBatchJob(clusterName string, imageURI string, curator clustercuratorv1.C
 			corev1.Container{
 				Name:            PreAJob,
 				Image:           imageURI,
-				Command:         append([]string{CurCmd, PreAJob}),
+				Command:         append([]string{CurCmd, PreAJob, clusterName}),
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Env: []corev1.EnvVar{
 					corev1.EnvVar{
@@ -310,7 +310,7 @@ func getBatchJob(clusterName string, imageURI string, curator clustercuratorv1.C
 		newJob.Spec.Template.Spec.InitContainers = append(newJob.Spec.Template.Spec.InitContainers, corev1.Container{
 			Name:            PostAJob,
 			Image:           imageURI,
-			Command:         append([]string{CurCmd, PostAJob}),
+			Command:         append([]string{CurCmd, PostAJob, clusterName}),
 			ImagePullPolicy: corev1.PullIfNotPresent,
 			Env: []corev1.EnvVar{
 				corev1.EnvVar{
@@ -326,12 +326,13 @@ func getBatchJob(clusterName string, imageURI string, curator clustercuratorv1.C
 
 func (I *Launcher) CreateJob() error {
 	kubeset := I.kubeset
-	clusterName := I.clusterCurator.Namespace
+	clusterName := I.clusterCurator.Name
+	clusterNamespace := I.clusterCurator.Namespace
 
-	newJob := getBatchJob(I.clusterCurator.Name, I.imageURI, I.clusterCurator)
+	newJob := getBatchJob(clusterName, clusterNamespace, I.imageURI, I.clusterCurator)
 
 	// Allow us to override the job in the Cluster Curator
-	klog.V(0).Info("Creating Curator job curator-job in namespace " + clusterName)
+	klog.V(0).Info("Creating Curator job curator-job in namespace " + clusterNamespace)
 	var err error
 	if I.clusterCurator.Spec.Install.OverrideJob != nil {
 		klog.V(0).Info(" Overriding the Curator job with overrideJob from the " + clusterName + " ClusterCurator resource")
@@ -352,10 +353,10 @@ func (I *Launcher) CreateJob() error {
 		}
 	}
 	if err == nil {
-		curatorJob, err := kubeset.BatchV1().Jobs(clusterName).Create(context.TODO(), newJob, v1.CreateOptions{})
+		curatorJob, err := kubeset.BatchV1().Jobs(clusterNamespace).Create(context.TODO(), newJob, v1.CreateOptions{})
 		if err == nil {
 			klog.V(0).Infof(" Created Curator job  ✓ (%v)", curatorJob.Name)
-			err = utils.RecordCuratorJobName(I.client, clusterName, curatorJob.Name)
+			err = utils.RecordCuratorJobName(I.client, clusterName, clusterNamespace, curatorJob.Name)
 			if err != nil {
 				return err
 			}

--- a/pkg/controller/launcher/job.go
+++ b/pkg/controller/launcher/job.go
@@ -53,7 +53,11 @@ func NewLauncher(
 	}
 }
 
-func getBatchJob(clusterName string, clusterNamespace string, imageURI string, curator clustercuratorv1.ClusterCurator) *batchv1.Job {
+func getBatchJob(
+	clusterName string,
+	clusterNamespace string,
+	imageURI string,
+	curator clustercuratorv1.ClusterCurator) *batchv1.Job {
 
 	var ttlf int32 = 3600
 

--- a/pkg/controller/launcher/job_test.go
+++ b/pkg/controller/launcher/job_test.go
@@ -47,7 +47,7 @@ func TestGetBatchJobImageSHA(t *testing.T) {
 			},
 		},
 	}
-	batchJobObj := getBatchJob(clusterName, imageURI, clusterCurator)
+	batchJobObj := getBatchJob(clusterName, clusterName, imageURI, clusterCurator)
 
 	t.Log("Test count initContainers in job")
 	foundInitContainers := len(batchJobObj.Spec.Template.Spec.InitContainers)
@@ -185,7 +185,7 @@ func TestGetBatchJobImageDefault(t *testing.T) {
 	}
 
 	for _, c := range testcases {
-		c.verify(getBatchJob(clusterName, imageURI, c.clusterCurator))
+		c.verify(getBatchJob(clusterName, clusterName, imageURI, c.clusterCurator))
 	}
 }
 
@@ -213,7 +213,7 @@ func TestGetBatchJobRetryInstallPosthook(t *testing.T) {
 		},
 	}
 
-	batchJobObj := getBatchJob(clusterName, imageURI, clusterCurator)
+	batchJobObj := getBatchJob(clusterName, clusterName, imageURI, clusterCurator)
 
 	t.Log("Test count initContainers in job")
 	foundInitContainers := len(batchJobObj.Spec.Template.Spec.InitContainers)
@@ -257,7 +257,7 @@ func TestGetBatchJobRetryUpgradePosthook(t *testing.T) {
 		},
 	}
 
-	batchJobObj := getBatchJob(clusterName, imageURI, clusterCurator)
+	batchJobObj := getBatchJob(clusterName, clusterName, imageURI, clusterCurator)
 
 	t.Log("Test count initContainers in job")
 	foundInitContainers := len(batchJobObj.Spec.Template.Spec.InitContainers)

--- a/pkg/jobs/ansible/job.go
+++ b/pkg/jobs/ansible/job.go
@@ -415,6 +415,7 @@ func MonitorAnsibleJob(
 
 	utils.CheckError(utils.RecordCurrentStatusCondition(
 		client,
+		curator.Name,
 		curator.Namespace,
 		"current-ansiblejob",
 		v1.ConditionFalse,
@@ -453,6 +454,7 @@ func MonitorAnsibleJob(
 			if !foundUrlOnce && jobStatusUrl != nil {
 				utils.CheckError(utils.RecordAnsibleJobStatusUrlCondition(
 					client,
+					curator.Name,
 					curator.Namespace,
 					jobResource.GetName(),
 					v1.ConditionTrue,
@@ -469,6 +471,7 @@ func MonitorAnsibleJob(
 
 				utils.CheckError(utils.RecordCurrentStatusCondition(
 					client,
+					curator.Name,
 					curator.Namespace,
 					"current-ansiblejob",
 					v1.ConditionTrue,

--- a/pkg/jobs/hive/hive.go
+++ b/pkg/jobs/hive/hive.go
@@ -74,19 +74,7 @@ func MonitorClusterStatus(
 		return err
 	}
 
-	return monitorClusterStatus(client, hiveset, clusterName, jobType, getMonitorAttempts(jobType, curator))
-}
-
-func getMonitorAttempts(jobType string, curator *clustercuratorv1.ClusterCurator) int {
-	monitorAttempts := utils.GetRetryTimes(0, 5, utils.PauseTwoSeconds)
-	switch jobType {
-	case utils.Installing:
-		monitorAttempts = utils.GetRetryTimes(curator.Spec.Install.JobMonitorTimeout, 5, utils.PauseTwoSeconds)
-	case utils.Destroying:
-		monitorAttempts = utils.GetRetryTimes(curator.Spec.Destroy.JobMonitorTimeout, 5, utils.PauseTwoSeconds)
-	}
-
-	return monitorAttempts
+	return monitorClusterStatus(client, hiveset, clusterName, jobType, utils.GetMonitorAttempts(jobType, curator))
 }
 
 func DestroyClusterDeployment(hiveset hiveclient.Interface, clusterName string) error {
@@ -140,6 +128,7 @@ func monitorClusterStatus(client clientv1.Client, hiveset hiveclient.Interface, 
 				utils.CheckError(utils.RecordCurrentStatusCondition(
 					client,
 					clusterName,
+					clusterName,
 					"hive-provisioning-job",
 					v1.ConditionTrue,
 					jobName))
@@ -184,6 +173,7 @@ func monitorClusterStatus(client clientv1.Client, hiveset hiveclient.Interface, 
 			utils.CheckError(utils.RecordCurrentStatusCondition(
 				client,
 				clusterName,
+				clusterName,
 				"hive-"+jobType+"ing-job",
 				v1.ConditionFalse,
 				jobName))
@@ -214,6 +204,7 @@ func monitorClusterStatus(client clientv1.Client, hiveset hiveclient.Interface, 
 				klog.V(0).Info("Uninstall job complete")
 				utils.CheckError(utils.RecordCurrentStatusCondition(
 					client,
+					clusterName,
 					clusterName,
 					"hive-"+jobType+"ing-job",
 					v1.ConditionTrue,
@@ -483,6 +474,7 @@ func MonitorUpgradeStatus(client clientv1.Client, clusterName string, curator *c
 						strMessage := "Upgrade status - " + condition.(map[string]interface{})["message"].(string)
 						utils.CheckError(utils.RecordCurrentStatusCondition(
 							client,
+							clusterName,
 							clusterName,
 							"monitor-upgrade",
 							v1.ConditionFalse,

--- a/pkg/jobs/hive/hive_test.go
+++ b/pkg/jobs/hive/hive_test.go
@@ -1000,26 +1000,3 @@ func TestMonitorUpgradeStatusJobComplete(t *testing.T) {
 
 	assert.Nil(t, MonitorUpgradeStatus(client, ClusterName, cc), "err is nil, when cluster upgrade is successful")
 }
-
-func TestGetMonitorAttempts(t *testing.T) {
-	attempts := getMonitorAttempts("", &clustercuratorv1.ClusterCurator{})
-	assert.Equal(t, 150, attempts)
-
-	attempts = getMonitorAttempts("provision", &clustercuratorv1.ClusterCurator{
-		Spec: clustercuratorv1.ClusterCuratorSpec{
-			Install: clustercuratorv1.Hooks{
-				JobMonitorTimeout: 6,
-			},
-		},
-	})
-	assert.Equal(t, 180, attempts)
-
-	attempts = getMonitorAttempts("uninstall", &clustercuratorv1.ClusterCurator{
-		Spec: clustercuratorv1.ClusterCuratorSpec{
-			Destroy: clustercuratorv1.Hooks{
-				JobMonitorTimeout: 15,
-			},
-		},
-	})
-	assert.Equal(t, 450, attempts)
-}

--- a/pkg/jobs/hypershift/hypershift.go
+++ b/pkg/jobs/hypershift/hypershift.go
@@ -1,0 +1,501 @@
+// Copyright Contributors to the Open Cluster Management project.
+package hypershift
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log"
+	"strconv"
+	"strings"
+	"time"
+
+	clustercuratorv1 "github.com/stolostron/cluster-curator-controller/pkg/api/v1beta1"
+	"github.com/stolostron/cluster-curator-controller/pkg/jobs/utils"
+	managedclusterinfov1beta1 "github.com/stolostron/cluster-lifecycle-api/clusterinfo/v1beta1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/klog/v2"
+	clientv1 "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+/*
+We must use dynamic types here unfortunately because the Hypershift API requires
+an older version of sigs.k8s.io/controller-runtime/pkg/client(v0.13.1) which is
+not compatible with the version	that the Hive API requires and results in compile issues.
+*/
+func ActivateDeploy(dc dynamic.Interface, clusterName string, namespace string) error {
+	klog.V(0).Info("* Initiate Hypershift Provisioning")
+
+	// Update HostedCluster
+	err := removePausedUntil(dc, clusterName, namespace, utils.HCGVR)
+	if err != nil {
+		return err
+	}
+
+	// Update NodePool
+	// Need to account for 0 or multiple NodePools
+	nodePools, err := dc.Resource(utils.NPGVR).Namespace(namespace).List(context.TODO(), v1.ListOptions{})
+	utils.CheckError(err)
+
+	for _, np := range nodePools.Items {
+		spec := np.Object["spec"].(map[string]interface{})
+		npClusterName := spec["clusterName"].(string)
+		if npClusterName == clusterName {
+			npName := np.Object["metadata"].(map[string]interface{})["name"].(string)
+			err = removePausedUntil(dc, npName, namespace, utils.NPGVR)
+			utils.CheckError(err)
+		}
+	}
+
+	return nil
+}
+
+func removePausedUntil(dc dynamic.Interface, clusterName string, namespace string, resourceType schema.GroupVersionResource) error {
+	klog.V(2).Infof("Looking up %v %v namespace %v", resourceType.Resource, clusterName, namespace)
+
+	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		var resource *unstructured.Unstructured
+		var err error
+
+		resource, err = dc.Resource(resourceType).Namespace(namespace).Get(context.TODO(), clusterName, v1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		metadata := resource.Object["metadata"].(map[string]interface{})
+		if resourceType.Resource == "nodepools" {
+			clusterName = metadata["name"].(string)
+		}
+		klog.V(2).Infof("Found %v %v in namespace %v ✓", resourceType.Resource, clusterName, metadata["namespace"].(string))
+
+		spec := resource.Object["spec"].(map[string]interface{})
+		if spec["pausedUntil"] != nil && spec["pausedUntil"].(string) != "true" {
+			log.Println("Handle " + resourceType.Resource + " directly")
+			return nil
+		}
+
+		// Remove the pause spec
+		patch := []utils.PatchStringValue{{
+			Op:   "remove",
+			Path: "/spec/pausedUntil",
+		}}
+
+		patchInBytes, _ := json.Marshal(patch)
+
+		klog.V(2).Infof("Patching %v %v in namespace %v ✓", resourceType.Resource, clusterName, metadata["namespace"].(string))
+		_, err = dc.Resource(resourceType).Namespace(namespace).Patch(
+			context.TODO(), clusterName, types.JSONPatchType, patchInBytes, v1.PatchOptions{})
+		if err != nil {
+			return err
+		}
+		log.Println("Updated " + resourceType.Resource + " ✓")
+		return nil
+	})
+
+	return err
+}
+
+func MonitorClusterStatus(dc dynamic.Interface, client clientv1.Client, clusterName string, namespace string, jobType string, monitorAttempts int) error {
+	klog.V(0).Info("Waiting up to " + strconv.Itoa(monitorAttempts*5) + "s for Hypershift Provisioning job")
+	jobName := ""
+	var hostedCluster *unstructured.Unstructured
+
+	for i := 1; i <= monitorAttempts; i++ {
+
+		// Refresh the hostedCluster resource
+		hostedCluster, err := dc.Resource(utils.HCGVR).Namespace(namespace).Get(context.TODO(), clusterName, v1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		// Destroy path
+		if err = utils.LogError(err); err != nil {
+			// If the hostedCluster is already gone
+			if jobType == utils.Destroying && k8serrors.IsNotFound(err) {
+				klog.Warning("No hosted cluster for " + clusterName + " was found")
+				return nil
+			}
+			return err
+		}
+
+		// Install path
+		if jobType == utils.Installing && isHostedReady(hostedCluster, false) {
+			klog.V(2).Info("Provisioning succeeded ✓")
+
+			if jobName != "" {
+				utils.CheckError(utils.RecordCurrentStatusCondition(
+					client,
+					clusterName,
+					namespace,
+					"hypershift-provisioning-job",
+					v1.ConditionTrue,
+					jobName))
+			}
+
+			return nil
+		} else if !isHostedReady(hostedCluster, false) || jobType == utils.Destroying {
+			klog.V(2).Info("Found HostedCluster status details ✓")
+
+			if jobType == utils.Destroying {
+				jobName = clusterName + "-" + utils.Destroying
+			} else {
+				// No ProvisionRef in HostedCluster, we use infra-id instead
+				metadata := hostedCluster.Object["metadata"].(map[string]interface{})
+				labels := metadata["labels"].(map[string]interface{})
+				jobName = labels["hypershift.openshift.io/auto-created-for-infra"].(string) + "-provision"
+			}
+
+			jobPath := namespace + "/" + jobName
+
+			klog.V(2).Info("Found job " + jobPath + " ✓ Start monitoring: ")
+			elapsedTime := 0
+
+			// Wait while the job is running
+			klog.V(0).Info("Wait for the " + jobType + "ing job from Hypershift to complete")
+
+			utils.CheckError(utils.RecordCurrentStatusCondition(
+				client,
+				clusterName,
+				namespace,
+				"hypershift-"+jobType+"ing-job",
+				v1.ConditionFalse,
+				jobName))
+
+			for !isHostedReady(hostedCluster, false) {
+				if elapsedTime%6 == 0 {
+					klog.V(0).Info("Job: " + jobPath + " - " + strconv.Itoa(elapsedTime/6) + "min")
+				}
+				time.Sleep(utils.PauseTenSeconds) // 10s
+				elapsedTime++
+
+				// Reset hostedCluster, so we make sure we're getting clean data (not cached)
+				hostedCluster, err = dc.Resource(utils.HCGVR).Namespace(namespace).Get(context.TODO(), clusterName, v1.GetOptions{})
+
+				if jobType == utils.Destroying && err != nil && k8serrors.IsNotFound(err) {
+					break
+				}
+
+				utils.CheckError(err)
+			}
+
+			// When Destroying, by this point the job finished
+			if jobType == utils.Destroying {
+				klog.V(0).Info("Uninstall job complete")
+				utils.CheckError(utils.RecordCurrentStatusCondition(
+					client,
+					clusterName,
+					namespace,
+					"hypershift-"+jobType+"ing-job",
+					v1.ConditionTrue,
+					jobName))
+				return nil
+			}
+
+			klog.V(0).Info("The " + jobType + "ing job from Hypershift completed ✓")
+		} else {
+			klog.V(0).Info("The " + jobType + "ing job from Hypershift failed ✓")
+			/*
+				  Detect that we've failed but there's no Hypershift equivalent of ProvisionStoppedCondition.
+					The problem with trying to detect failure for hypershift is that there's no total failure state
+					where the operator will give up trying. Users can always fix an issue ie. WebIdentity error to
+					allow the provision to continue.
+			*/
+		}
+	}
+
+	if hostedCluster != nil {
+		klog.Warning(hostedCluster.Object["status"].(map[string]interface{})["conditions"])
+	}
+	return errors.New("Timed out waiting for job")
+}
+
+func isHostedReady(hostedCluster *unstructured.Unstructured, isUpgrade bool) bool {
+	status := hostedCluster.Object["status"].(map[string]interface{})
+	conditions := status["conditions"].([]interface{})
+	degraded := true
+	clusterVersionProgressing := true
+	clusterVersionProgressingMsg := ""
+	clusterVersionAvailable := false
+	clusterVersionAvailableMsg := ""
+	available := false
+	progressing := false
+
+	for _, condition := range conditions {
+		conditionType := condition.(map[string]interface{})["type"].(string)
+		conditionStatus := condition.(map[string]interface{})["status"].(string)
+
+		klog.V(4).Info("Type " + condition.(map[string]interface{})["type"].(string) + " Status " + condition.(map[string]interface{})["status"].(string))
+		switch conditionType {
+		case "Degraded":
+			degraded, _ = strconv.ParseBool(conditionStatus)
+		case "ClusterVersionAvailable":
+			clusterVersionAvailable, _ = strconv.ParseBool(conditionStatus)
+			clusterVersionAvailableMsg = condition.(map[string]interface{})["message"].(string)
+		case "ClusterVersionProgressing":
+			clusterVersionProgressing, _ = strconv.ParseBool(conditionStatus)
+			clusterVersionProgressingMsg = condition.(map[string]interface{})["message"].(string)
+		case "Available":
+			available, _ = strconv.ParseBool(conditionStatus)
+		case "Progressing":
+			progressing, _ = strconv.ParseBool(conditionStatus)
+		}
+	}
+
+	klog.V(4).Info("Available " + strconv.FormatBool(available))
+	if !available {
+		return false
+	}
+	klog.V(4).Info("degraded " + strconv.FormatBool(degraded))
+	if degraded {
+		return false
+	}
+	klog.V(4).Info("clusterVersionProgressing " + strconv.FormatBool(clusterVersionProgressing))
+	if clusterVersionProgressing {
+		return false
+	}
+	klog.V(4).Info("clusterVersionAvailable " + strconv.FormatBool(clusterVersionAvailable))
+	if !clusterVersionAvailable {
+		return false
+	}
+	klog.V(4).Info("clusterVersionProgressingMsg " + clusterVersionProgressingMsg)
+	if !strings.Contains(clusterVersionProgressingMsg, "Cluster version is") {
+		return false
+	}
+	klog.V(4).Info("clusterVersionAvailableMsg " + clusterVersionAvailableMsg)
+	if !strings.Contains(clusterVersionAvailableMsg, "Done applying") {
+		return false
+	}
+	klog.V(4).Info("progressing " + strconv.FormatBool(progressing))
+	if isUpgrade && progressing {
+		return false
+	}
+
+	return true
+}
+
+func UpgradeCluster(client clientv1.Client, dc dynamic.Interface, clusterName string, curator *clustercuratorv1.ClusterCurator) error {
+	klog.V(0).Info("* Initiate Upgrade")
+	klog.V(2).Info("Looking up managedclusterinfo " + clusterName)
+
+	desiredUpdate := curator.Spec.Upgrade.DesiredUpdate
+
+	if err := validateUpgradeVersion(client, clusterName, curator, desiredUpdate); err != nil {
+		return err
+	}
+
+	// Only support upgrading HC AND NPs to same versions for now
+	image := "quay.io/openshift-release-dev/ocp-release:" + desiredUpdate + "-multi"
+
+	// Patch HostedCluster with new image
+	err := patchUpgradeVersion(dc, clusterName, curator.Namespace, utils.HCGVR, image)
+	utils.CheckError(err)
+
+	// Need to account for 0 or multiple NodePools
+	nodePools, err := dc.Resource(utils.NPGVR).Namespace(curator.Namespace).List(context.TODO(), v1.ListOptions{})
+	utils.CheckError(err)
+
+	for _, np := range nodePools.Items {
+		spec := np.Object["spec"].(map[string]interface{})
+		npClusterName := spec["clusterName"].(string)
+		if npClusterName == clusterName {
+			npName := np.Object["metadata"].(map[string]interface{})["name"].(string)
+			err = patchUpgradeVersion(dc, npName, curator.Namespace, utils.NPGVR, image)
+			utils.CheckError(err)
+		}
+	}
+
+	return nil
+}
+
+func MonitorUpgradeStatus(dc dynamic.Interface, client clientv1.Client, clusterName string, curator *clustercuratorv1.ClusterCurator) error {
+	upgradeAttempts := utils.GetRetryTimes(curator.Spec.Upgrade.MonitorTimeout, 120, utils.PauseSixtySeconds)
+	klog.V(0).Info("Monitoring up to " + strconv.Itoa(upgradeAttempts) + " attempts for Hypershift Upgrade job")
+	elapsedTime := 0
+
+	// Refresh the hostedCluster resource
+	hostedCluster, err := dc.Resource(utils.HCGVR).Namespace(curator.Namespace).Get(context.TODO(), clusterName, v1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	for i := 0; i < upgradeAttempts; i++ {
+		if isHostedReady(hostedCluster, true) {
+			klog.V(2).Info("Upgrade succeeded ✓")
+			utils.CheckError(utils.RecordCurrentStatusCondition(
+				client,
+				clusterName,
+				curator.Namespace,
+				"hypershift-upgrade-job",
+				v1.ConditionTrue,
+				"upgrade-job"))
+
+			return nil
+		} else if !isHostedReady(hostedCluster, true) {
+			for !isHostedReady(hostedCluster, true) {
+				if elapsedTime%6 == 0 {
+					klog.V(0).Info("Upgrade Job:  - " + strconv.Itoa(elapsedTime/6) + "min")
+				}
+				time.Sleep(utils.PauseTenSeconds) // 10s
+				elapsedTime++
+
+				// Reset hostedCluster, so we make sure we're getting clean data (not cached)
+				hostedCluster, err = dc.Resource(utils.HCGVR).Namespace(curator.Namespace).Get(context.TODO(), clusterName, v1.GetOptions{})
+
+				if err != nil && k8serrors.IsNotFound(err) {
+					break
+				}
+
+				utils.CheckError(err)
+			}
+		}
+	}
+
+	if hostedCluster != nil {
+		klog.Warning(hostedCluster.Object["status"].(map[string]interface{})["conditions"])
+	}
+	return errors.New("Timed out waiting for job")
+}
+
+func patchUpgradeVersion(dc dynamic.Interface, clusterName string, namespace string, resourceType schema.GroupVersionResource, image string) error {
+	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		// Update the image spec
+		patch := []utils.PatchStringValue{{
+			Op:    "replace",
+			Path:  "/spec/release/image",
+			Value: image,
+		}}
+
+		patchInBytes, _ := json.Marshal(patch)
+
+		klog.V(2).Infof("Patching %v %v in namespace %v ✓", resourceType.Resource, clusterName, namespace)
+		_, err := dc.Resource(resourceType).Namespace(namespace).Patch(
+			context.TODO(), clusterName, types.JSONPatchType, patchInBytes, v1.PatchOptions{})
+		if err != nil {
+			return err
+		}
+		log.Println("Updated " + resourceType.Resource + " ✓")
+		return nil
+	})
+
+	return err
+}
+
+func validateUpgradeVersion(client clientv1.Client, clusterName string, curator *clustercuratorv1.ClusterCurator, desiredUpdate string) error {
+	managedClusterInfo := managedclusterinfov1beta1.ManagedClusterInfo{}
+	if err := client.Get(context.TODO(), types.NamespacedName{
+		Namespace: clusterName,
+		Name:      clusterName,
+	}, &managedClusterInfo); err != nil {
+		return err
+	}
+
+	if managedClusterInfo.Status.DistributionInfo.OCP.Version == desiredUpdate {
+		return errors.New("Cannot upgrade to the same version")
+	}
+
+	desiredUpdateSplit := strings.Split(desiredUpdate, ".")
+	currentVersionSplit := strings.Split(managedClusterInfo.Status.DistributionInfo.OCP.Version, ".")
+	desiredUpdateMajor, _ := strconv.Atoi(desiredUpdateSplit[0])
+	desiredUpdateMinor, _ := strconv.Atoi(desiredUpdateSplit[1])
+	desiredUpdatePatch, _ := strconv.Atoi(desiredUpdateSplit[2])
+	currentVersionMajor, _ := strconv.Atoi(currentVersionSplit[0])
+	currentVersionMinor, _ := strconv.Atoi(currentVersionSplit[1])
+	currentVersionPatch, _ := strconv.Atoi(currentVersionSplit[2])
+
+	lowerDesiredUpdateVersionErrMsg := "Cannot upgrade to an earlier version"
+
+	if desiredUpdateMajor < currentVersionMajor {
+		return errors.New(lowerDesiredUpdateVersionErrMsg)
+	}
+
+	if desiredUpdateMajor == currentVersionMajor && desiredUpdateMinor < currentVersionMinor {
+		return errors.New(lowerDesiredUpdateVersionErrMsg)
+	}
+
+	if desiredUpdateMajor == currentVersionMajor &&
+		desiredUpdateMinor == currentVersionMinor &&
+		desiredUpdatePatch < currentVersionPatch {
+		return errors.New(lowerDesiredUpdateVersionErrMsg)
+	}
+
+	return nil
+}
+
+func DestroyHostedCluster(dc dynamic.Interface, clusterName string, namespace string) error {
+	klog.V(0).Infof("Deleting Hosted Cluster for %v in namespace %v\n", clusterName, namespace)
+
+	_, err := dc.Resource(utils.HCGVR).Namespace(namespace).Get(context.TODO(), clusterName, v1.GetOptions{})
+
+	if err != nil && k8serrors.IsNotFound(err) {
+		klog.Warning("Could not retreive hosted cluster " + clusterName + " may have already been deleted")
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	err = dc.Resource(utils.HCGVR).Namespace(namespace).Delete(context.TODO(), clusterName, v1.DeleteOptions{})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func DetachAndMonitor(dc dynamic.Interface, clusterName string, curator *clustercuratorv1.ClusterCurator) error {
+	var mcGVR = schema.GroupVersionResource{
+		Group:    "cluster.open-cluster-management.io",
+		Version:  "v1",
+		Resource: "managedclusters",
+	}
+	klog.V(0).Info("=> Monitoring ManagedCluster detach of " + clusterName)
+
+	hostedCluster, err := dc.Resource(utils.HCGVR).Namespace(curator.Namespace).Get(context.TODO(), clusterName, v1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	spec := hostedCluster.Object["spec"].(map[string]interface{})
+	hcType := spec["platform"].(map[string]interface{})["type"].(string)
+
+	if hcType != "KubeVirt" && hcType != "Agent" {
+		return errors.New("Destroying HosterCluster type " + hcType + " is not supported. Use the HostedCluster CLI.")
+	}
+
+	retryCount := utils.GetRetryTimes(curator.Spec.Install.JobMonitorTimeout, 5, utils.PauseTwoSeconds)
+	_, err = dc.Resource(mcGVR).Get(context.TODO(), clusterName, v1.GetOptions{})
+
+	if err != nil && k8serrors.IsNotFound(err) {
+		klog.Warning("Could not retreive managed cluster " + clusterName + " may have been deleted")
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	klog.V(0).Info("Deleting ManagedCluster " + clusterName)
+	// Delete will hang until resource is delete, no need to monitor
+	err = dc.Resource(mcGVR).Delete(context.TODO(), clusterName, v1.DeleteOptions{})
+	if err != nil {
+		return err
+	}
+
+	// Monitor managed cluster delete
+	for i := 1; i <= retryCount; i++ {
+		_, err := dc.Resource(mcGVR).Get(context.TODO(), clusterName, v1.GetOptions{})
+
+		if err != nil && k8serrors.IsNotFound(err) {
+			klog.Warning("Could not retreive managed cluster " + clusterName + " may have been deleted")
+			return nil
+		} else if err != nil {
+			return err
+		}
+
+		time.Sleep(utils.PauseTenSeconds * 3)
+	}
+	return errors.New("Time out waiting for hosted cluster to detach")
+}

--- a/pkg/jobs/hypershift/hypershift_test.go
+++ b/pkg/jobs/hypershift/hypershift_test.go
@@ -1,0 +1,703 @@
+// Copyright Contributors to the Open Cluster Management project.
+
+package hypershift
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	clustercuratorv1 "github.com/stolostron/cluster-curator-controller/pkg/api/v1beta1"
+	"github.com/stolostron/cluster-curator-controller/pkg/jobs/utils"
+	managedclusterinfov1beta1 "github.com/stolostron/cluster-lifecycle-api/clusterinfo/v1beta1"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	dynfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/scheme"
+	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const ClusterName = "my-cluster"
+const ClusterNamespace = "clusters"
+const NodepoolName = "my-cluster-us-east-2"
+const testTimeout = 5
+
+var s = scheme.Scheme
+
+func getHostedCluster(hcType string, hcConditions []interface{}) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "hypershift.openshift.io/v1beta1",
+			"kind":       "HostedCluster",
+			"metadata": map[string]interface{}{
+				"name":      ClusterName,
+				"namespace": ClusterNamespace,
+				"labels": map[string]interface{}{
+					"hypershift.openshift.io/auto-created-for-infra": ClusterName + "-xyz",
+				},
+			},
+			"spec": map[string]interface{}{
+				"pausedUntil": "true",
+				"platform": map[string]interface{}{
+					"type": hcType,
+				},
+				"release": map[string]interface{}{
+					"image": "quay.io/openshift-release-dev/ocp-release:4.13.6-multi",
+				},
+			},
+			"status": map[string]interface{}{
+				"conditions": hcConditions,
+			},
+		},
+	}
+}
+
+func getNodepool(npName string, npNamespace string, npClusterName string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "hypershift.openshift.io/v1beta1",
+			"kind":       "NodePool",
+			"metadata": map[string]interface{}{
+				"name":      npName,
+				"namespace": npNamespace,
+			},
+			"spec": map[string]interface{}{
+				"pausedUntil": "true",
+				"clusterName": npClusterName,
+				"release": map[string]interface{}{
+					"image": "quay.io/openshift-release-dev/ocp-release:4.13.6-multi",
+				},
+			},
+		},
+	}
+}
+
+func getClusterCurator(desiredCuration string) *clustercuratorv1.ClusterCurator {
+	return &clustercuratorv1.ClusterCurator{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      ClusterName,
+			Namespace: ClusterNamespace,
+		},
+		Spec: clustercuratorv1.ClusterCuratorSpec{
+			DesiredCuration: desiredCuration,
+		},
+	}
+}
+
+func getUpgradeClusterCurator(desiredUpdate string) *clustercuratorv1.ClusterCurator {
+	return &clustercuratorv1.ClusterCurator{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      ClusterName,
+			Namespace: ClusterNamespace,
+		},
+		Spec: clustercuratorv1.ClusterCuratorSpec{
+			DesiredCuration: "upgrade",
+			Upgrade: clustercuratorv1.UpgradeHooks{
+				DesiredUpdate:  desiredUpdate,
+				MonitorTimeout: 5,
+			},
+			Destroy: clustercuratorv1.Hooks{
+				JobMonitorTimeout: 1,
+			},
+		},
+	}
+}
+
+func getManagedClusterInfo() *managedclusterinfov1beta1.ManagedClusterInfo {
+	return &managedclusterinfov1beta1.ManagedClusterInfo{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      ClusterName,
+			Namespace: ClusterName,
+		},
+		Status: managedclusterinfov1beta1.ClusterInfoStatus{
+			DistributionInfo: managedclusterinfov1beta1.DistributionInfo{
+				OCP: managedclusterinfov1beta1.OCPDistributionInfo{
+					Version: "4.13.6",
+				},
+			},
+		},
+	}
+}
+
+func getManagedCluster() *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "cluster.open-cluster-management.io/v1",
+			"kind":       "ManagedCluster",
+			"metadata": map[string]interface{}{
+				"name": ClusterName,
+			},
+		},
+	}
+}
+
+func TestActivateDeployNoHC(t *testing.T) {
+	dynfake := dynfake.NewSimpleDynamicClient(runtime.NewScheme())
+	assert.NotNil(t, ActivateDeploy(
+		dynfake, ClusterName, ClusterNamespace), "err not nil, when HostedCluster resource is not present")
+}
+
+func TestActivateDeployAvailable(t *testing.T) {
+	dynfake := dynfake.NewSimpleDynamicClient(
+		runtime.NewScheme(),
+		getHostedCluster("AWS", []interface{}{}),
+		getNodepool(NodepoolName, ClusterNamespace, ClusterName),
+		getNodepool("other-cluster-us-east-2", ClusterNamespace, "other-cluster"))
+	assert.Nil(t, ActivateDeploy(
+		dynfake, ClusterName, ClusterNamespace), "err nil, when HostedCluster is available")
+}
+
+func TestMonitorClusterStatusInstallNoHC(t *testing.T) {
+	clusterCurator := &clustercuratorv1.ClusterCurator{}
+	dynfake := dynfake.NewSimpleDynamicClient(runtime.NewScheme())
+	s.AddKnownTypes(clustercuratorv1.SchemeBuilder.GroupVersion, &clustercuratorv1.ClusterCurator{})
+	client := clientfake.NewFakeClientWithScheme(s, clusterCurator)
+
+	assert.NotNil(
+		t,
+		MonitorClusterStatus(dynfake, client, ClusterName, ClusterNamespace, utils.Installing, testTimeout),
+		"err is not nil, when HostedCluster does not exist",
+	)
+}
+
+func TestMonitorClusterStatusDestroyComplete(t *testing.T) {
+	clusterCurator := &clustercuratorv1.ClusterCurator{}
+	dynfake := dynfake.NewSimpleDynamicClient(runtime.NewScheme())
+	s.AddKnownTypes(clustercuratorv1.SchemeBuilder.GroupVersion, &clustercuratorv1.ClusterCurator{})
+	client := clientfake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(clusterCurator).Build()
+
+	assert.Nil(
+		t,
+		MonitorClusterStatus(dynfake, client, ClusterName, ClusterNamespace, utils.Destroying, testTimeout),
+		"err is nil, when HostedCluster is deleted",
+	)
+}
+
+func TestMonitorClusterStatusInstallComplete(t *testing.T) {
+	clusterCurator := &clustercuratorv1.ClusterCurator{}
+	dynfake := dynfake.NewSimpleDynamicClient(
+		runtime.NewScheme(),
+		getHostedCluster("AWS", []interface{}{
+			map[string]interface{}{
+				"type":    "Degraded",
+				"status":  "False",
+				"message": "The hosted cluster is not degraded",
+			},
+			map[string]interface{}{
+				"type":    "ClusterVersionAvailable",
+				"status":  "True",
+				"message": "Done applying 4.13.6",
+			},
+			map[string]interface{}{
+				"type":    "Available",
+				"status":  "True",
+				"message": "The hosted control plane is available",
+			},
+			map[string]interface{}{
+				"type":    "ClusterVersionProgressing",
+				"status":  "False",
+				"message": "Cluster version is 4.13.6",
+			},
+		},
+		))
+	s.AddKnownTypes(clustercuratorv1.SchemeBuilder.GroupVersion, &clustercuratorv1.ClusterCurator{})
+	client := clientfake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(clusterCurator).Build()
+
+	assert.Nil(
+		t,
+		MonitorClusterStatus(dynfake, client, ClusterName, ClusterNamespace, utils.Installing, testTimeout),
+		"err is nil, when HostedCluster install is complete",
+	)
+}
+
+func TestMonitorClusterStatusWaitForDestroyToComplete(t *testing.T) {
+	clusterCurator := getClusterCurator(utils.Destroying)
+	dynfake := dynfake.NewSimpleDynamicClient(
+		runtime.NewScheme(),
+		getHostedCluster("AWS", []interface{}{
+			map[string]interface{}{
+				"type":    "Degraded",
+				"status":  "True",
+				"message": "The hosted cluster is not degraded",
+			},
+			map[string]interface{}{
+				"type":    "ClusterVersionAvailable",
+				"status":  "True",
+				"message": "Done applying 4.13.6",
+			},
+			map[string]interface{}{
+				"type":    "Available",
+				"status":  "True",
+				"message": "The hosted control plane is available",
+			},
+			map[string]interface{}{
+				"type":    "ClusterVersionProgressing",
+				"status":  "False",
+				"message": "Cluster version is 4.13.6",
+			},
+		},
+		))
+	s.AddKnownTypes(clustercuratorv1.SchemeBuilder.GroupVersion, &clustercuratorv1.ClusterCurator{})
+	client := clientfake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(clusterCurator).Build()
+
+	go func() {
+		time.Sleep(utils.PauseTenSeconds)
+
+		err := dynfake.Resource(utils.HCGVR).Namespace(ClusterNamespace).Delete(context.TODO(), ClusterName, v1.DeleteOptions{})
+		assert.Nil(t, err, "err is nil, when HostedCluster is deleted successfully")
+	}()
+
+	assert.Nil(
+		t,
+		MonitorClusterStatus(dynfake, client, ClusterName, ClusterNamespace, utils.Destroying, testTimeout),
+		"err is nil, when HostedCluster is deleted successfully",
+	)
+}
+
+func TestMonitorClusterStatusWaitForInstallToComplete(t *testing.T) {
+	clusterCurator := getClusterCurator(utils.Installing)
+	dynfake := dynfake.NewSimpleDynamicClient(
+		runtime.NewScheme(),
+		getHostedCluster("AWS", []interface{}{
+			map[string]interface{}{
+				"type":    "Degraded",
+				"status":  "True",
+				"message": "The hosted cluster is not degraded",
+			},
+			map[string]interface{}{
+				"type":    "ClusterVersionAvailable",
+				"status":  "False",
+				"message": "Done applying 4.13.6",
+			},
+			map[string]interface{}{
+				"type":    "Available",
+				"status":  "False",
+				"message": "The hosted control plane is available",
+			},
+			map[string]interface{}{
+				"type":    "ClusterVersionProgressing",
+				"status":  "False",
+				"message": "Cluster version is 4.13.6",
+			},
+		},
+		))
+	s.AddKnownTypes(clustercuratorv1.SchemeBuilder.GroupVersion, &clustercuratorv1.ClusterCurator{})
+	client := clientfake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(clusterCurator).Build()
+
+	go func() {
+		time.Sleep(utils.PauseTenSeconds)
+
+		newHC := getHostedCluster("AWS", []interface{}{
+			map[string]interface{}{
+				"type":    "Degraded",
+				"status":  "False",
+				"message": "The hosted cluster is not degraded",
+			},
+			map[string]interface{}{
+				"type":    "ClusterVersionAvailable",
+				"status":  "True",
+				"message": "Done applying 4.13.6",
+			},
+			map[string]interface{}{
+				"type":    "Available",
+				"status":  "True",
+				"message": "The hosted control plane is available",
+			},
+			map[string]interface{}{
+				"type":    "ClusterVersionProgressing",
+				"status":  "False",
+				"message": "Cluster version is 4.13.6",
+			},
+		})
+		_, err := dynfake.Resource(utils.HCGVR).Namespace(ClusterNamespace).Update(context.TODO(), newHC, v1.UpdateOptions{})
+		assert.Nil(t, err, "err is nil, when HostedCluster is updated successfully")
+	}()
+
+	assert.Nil(
+		t,
+		MonitorClusterStatus(dynfake, client, ClusterName, ClusterNamespace, utils.Installing, testTimeout),
+		"err is nil, when HostedCluster is deleted successfully",
+	)
+}
+
+func TestUpgradeClusterCompleted(t *testing.T) {
+	clusterCurator := getUpgradeClusterCurator("4.13.7")
+	managedClusterInfo := getManagedClusterInfo()
+	dynfake := dynfake.NewSimpleDynamicClient(
+		runtime.NewScheme(),
+		getHostedCluster("AWS", []interface{}{
+			map[string]interface{}{
+				"type":    "Degraded",
+				"status":  "False",
+				"message": "The hosted cluster is not degraded",
+			},
+			map[string]interface{}{
+				"type":    "ClusterVersionAvailable",
+				"status":  "True",
+				"message": "Done applying 4.13.6",
+			},
+			map[string]interface{}{
+				"type":    "Available",
+				"status":  "False",
+				"message": "The hosted control plane is available",
+			},
+			map[string]interface{}{
+				"type":    "ClusterVersionProgressing",
+				"status":  "False",
+				"message": "Cluster version is 4.13.6",
+			},
+			map[string]interface{}{
+				"type":    "Progressing",
+				"status":  "False",
+				"message": "HostedCluster is at expected version",
+			},
+		}),
+		getNodepool(NodepoolName, ClusterNamespace, ClusterName),
+	)
+	s.AddKnownTypes(clustercuratorv1.SchemeBuilder.GroupVersion, &clustercuratorv1.ClusterCurator{})
+	s.AddKnownTypes(managedclusterinfov1beta1.SchemeGroupVersion, &managedclusterinfov1beta1.ManagedClusterInfo{})
+	client := clientfake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(clusterCurator, managedClusterInfo).Build()
+
+	assert.Nil(
+		t,
+		UpgradeCluster(client, dynfake, ClusterName, clusterCurator),
+		"err is nil, when HC and NPs are patched successfully for upgrade",
+	)
+}
+
+func TestUpgradeClusterSameVersion(t *testing.T) {
+	clusterCurator := getUpgradeClusterCurator("4.13.6")
+	managedClusterInfo := getManagedClusterInfo()
+	dynfake := dynfake.NewSimpleDynamicClient(
+		runtime.NewScheme(),
+		getHostedCluster("AWS", []interface{}{
+			map[string]interface{}{
+				"type":    "Degraded",
+				"status":  "False",
+				"message": "The hosted cluster is not degraded",
+			},
+			map[string]interface{}{
+				"type":    "ClusterVersionAvailable",
+				"status":  "True",
+				"message": "Done applying 4.13.6",
+			},
+			map[string]interface{}{
+				"type":    "Available",
+				"status":  "False",
+				"message": "The hosted control plane is available",
+			},
+			map[string]interface{}{
+				"type":    "ClusterVersionProgressing",
+				"status":  "False",
+				"message": "Cluster version is 4.13.6",
+			},
+			map[string]interface{}{
+				"type":    "Progressing",
+				"status":  "False",
+				"message": "HostedCluster is at expected version",
+			},
+		}),
+		getNodepool(NodepoolName, ClusterNamespace, ClusterName),
+	)
+	s.AddKnownTypes(clustercuratorv1.SchemeBuilder.GroupVersion, &clustercuratorv1.ClusterCurator{})
+	s.AddKnownTypes(managedclusterinfov1beta1.SchemeGroupVersion, &managedclusterinfov1beta1.ManagedClusterInfo{})
+	client := clientfake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(clusterCurator, managedClusterInfo).Build()
+
+	assert.NotNil(
+		t,
+		UpgradeCluster(client, dynfake, ClusterName, clusterCurator),
+		"err is not nil, when HC and NPs are upgrading to the same version",
+	)
+}
+
+func TestUpgradeClusterEarlierVersion(t *testing.T) {
+	clusterCurator := getUpgradeClusterCurator("4.13.5")
+	managedClusterInfo := getManagedClusterInfo()
+	dynfake := dynfake.NewSimpleDynamicClient(
+		runtime.NewScheme(),
+		getHostedCluster("AWS", []interface{}{
+			map[string]interface{}{
+				"type":    "Degraded",
+				"status":  "False",
+				"message": "The hosted cluster is not degraded",
+			},
+			map[string]interface{}{
+				"type":    "ClusterVersionAvailable",
+				"status":  "True",
+				"message": "Done applying 4.13.6",
+			},
+			map[string]interface{}{
+				"type":    "Available",
+				"status":  "False",
+				"message": "The hosted control plane is available",
+			},
+			map[string]interface{}{
+				"type":    "ClusterVersionProgressing",
+				"status":  "False",
+				"message": "Cluster version is 4.13.6",
+			},
+			map[string]interface{}{
+				"type":    "Progressing",
+				"status":  "False",
+				"message": "HostedCluster is at expected version",
+			},
+		}),
+		getNodepool(NodepoolName, ClusterNamespace, ClusterName),
+	)
+	s.AddKnownTypes(clustercuratorv1.SchemeBuilder.GroupVersion, &clustercuratorv1.ClusterCurator{})
+	s.AddKnownTypes(managedclusterinfov1beta1.SchemeGroupVersion, &managedclusterinfov1beta1.ManagedClusterInfo{})
+	client := clientfake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(clusterCurator, managedClusterInfo).Build()
+
+	assert.NotNil(
+		t,
+		UpgradeCluster(client, dynfake, ClusterName, clusterCurator),
+		"err is not nil, when HC and NPs are upgrading to an earlier version",
+	)
+}
+
+func TestMonitorUpgradeStatusCompleted(t *testing.T) {
+	clusterCurator := getUpgradeClusterCurator("4.13.7")
+	managedClusterInfo := getManagedClusterInfo()
+	dynfake := dynfake.NewSimpleDynamicClient(
+		runtime.NewScheme(),
+		getHostedCluster("AWS", []interface{}{
+			map[string]interface{}{
+				"type":    "Degraded",
+				"status":  "False",
+				"message": "The hosted cluster is not degraded",
+			},
+			map[string]interface{}{
+				"type":    "ClusterVersionAvailable",
+				"status":  "True",
+				"message": "Done applying 4.13.7",
+			},
+			map[string]interface{}{
+				"type":    "Available",
+				"status":  "True",
+				"message": "The hosted control plane is available",
+			},
+			map[string]interface{}{
+				"type":    "ClusterVersionProgressing",
+				"status":  "False",
+				"message": "Cluster version is 4.13.7",
+			},
+			map[string]interface{}{
+				"type":    "Progressing",
+				"status":  "False",
+				"message": "HostedCluster is at expected version",
+			},
+		}),
+		getNodepool(NodepoolName, ClusterNamespace, ClusterName),
+	)
+	s.AddKnownTypes(clustercuratorv1.SchemeBuilder.GroupVersion, &clustercuratorv1.ClusterCurator{})
+	s.AddKnownTypes(managedclusterinfov1beta1.SchemeGroupVersion, &managedclusterinfov1beta1.ManagedClusterInfo{})
+	client := clientfake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(clusterCurator, managedClusterInfo).Build()
+
+	assert.Nil(
+		t,
+		MonitorUpgradeStatus(dynfake, client, ClusterName, clusterCurator),
+		"err is nil, when HC and NPs are upgraded sucessfully",
+	)
+}
+
+func TestMonitorUpgradeStatusWaitForUpdate(t *testing.T) {
+	clusterCurator := getUpgradeClusterCurator("4.13.7")
+	managedClusterInfo := getManagedClusterInfo()
+	dynfake := dynfake.NewSimpleDynamicClient(
+		runtime.NewScheme(),
+		getHostedCluster("AWS", []interface{}{
+			map[string]interface{}{
+				"type":    "Degraded",
+				"status":  "False",
+				"message": "The hosted cluster is not degraded",
+			},
+			map[string]interface{}{
+				"type":    "ClusterVersionAvailable",
+				"status":  "True",
+				"message": "Done applying 4.13.7",
+			},
+			map[string]interface{}{
+				"type":    "Available",
+				"status":  "True",
+				"message": "The hosted control plane is available",
+			},
+			map[string]interface{}{
+				"type":    "ClusterVersionProgressing",
+				"status":  "False",
+				"message": "Cluster version is 4.13.7",
+			},
+			map[string]interface{}{
+				"type":    "Progressing",
+				"status":  "True",
+				"message": "HostedCluster is at expected version",
+			},
+		}),
+		getNodepool(NodepoolName, ClusterNamespace, ClusterName),
+	)
+	s.AddKnownTypes(clustercuratorv1.SchemeBuilder.GroupVersion, &clustercuratorv1.ClusterCurator{})
+	s.AddKnownTypes(managedclusterinfov1beta1.SchemeGroupVersion, &managedclusterinfov1beta1.ManagedClusterInfo{})
+	client := clientfake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(clusterCurator, managedClusterInfo).Build()
+
+	go func() {
+		time.Sleep(utils.PauseTenSeconds)
+
+		newHC := getHostedCluster("AWS", []interface{}{
+			map[string]interface{}{
+				"type":    "Degraded",
+				"status":  "False",
+				"message": "The hosted cluster is not degraded",
+			},
+			map[string]interface{}{
+				"type":    "ClusterVersionAvailable",
+				"status":  "True",
+				"message": "Done applying 4.13.7",
+			},
+			map[string]interface{}{
+				"type":    "Available",
+				"status":  "True",
+				"message": "The hosted control plane is available",
+			},
+			map[string]interface{}{
+				"type":    "ClusterVersionProgressing",
+				"status":  "False",
+				"message": "Cluster version is 4.13.7",
+			},
+			map[string]interface{}{
+				"type":    "Progressing",
+				"status":  "False",
+				"message": "HostedCluster is at expected version",
+			},
+		})
+		_, err := dynfake.Resource(utils.HCGVR).Namespace(ClusterNamespace).Update(context.TODO(), newHC, v1.UpdateOptions{})
+		assert.Nil(t, err, "err is nil, when HostedCluster is updated successfully")
+	}()
+
+	assert.Nil(
+		t,
+		MonitorUpgradeStatus(dynfake, client, ClusterName, clusterCurator),
+		"err is nil, when HC and NPs are upgraded sucessfully",
+	)
+}
+
+func TestDestroyHostedCluster(t *testing.T) {
+	dynfake := dynfake.NewSimpleDynamicClient(
+		runtime.NewScheme(),
+		getHostedCluster("AWS", []interface{}{
+			map[string]interface{}{
+				"type":    "Degraded",
+				"status":  "False",
+				"message": "The hosted cluster is not degraded",
+			},
+			map[string]interface{}{
+				"type":    "ClusterVersionAvailable",
+				"status":  "True",
+				"message": "Done applying 4.13.7",
+			},
+			map[string]interface{}{
+				"type":    "Available",
+				"status":  "True",
+				"message": "The hosted control plane is available",
+			},
+			map[string]interface{}{
+				"type":    "ClusterVersionProgressing",
+				"status":  "False",
+				"message": "Cluster version is 4.13.7",
+			},
+			map[string]interface{}{
+				"type":    "Progressing",
+				"status":  "True",
+				"message": "HostedCluster is at expected version",
+			},
+		}),
+	)
+
+	assert.Nil(
+		t,
+		DestroyHostedCluster(dynfake, ClusterName, ClusterNamespace),
+		"err is nil, when HC and NPs are upgraded sucessfully",
+	)
+}
+
+func TestDetachAndMonitorAWS(t *testing.T) {
+	clusterCurator := getUpgradeClusterCurator("4.13.7")
+	dynfake := dynfake.NewSimpleDynamicClient(
+		runtime.NewScheme(),
+		getHostedCluster("AWS", []interface{}{
+			map[string]interface{}{
+				"type":    "Degraded",
+				"status":  "False",
+				"message": "The hosted cluster is not degraded",
+			},
+			map[string]interface{}{
+				"type":    "ClusterVersionAvailable",
+				"status":  "True",
+				"message": "Done applying 4.13.7",
+			},
+			map[string]interface{}{
+				"type":    "Available",
+				"status":  "True",
+				"message": "The hosted control plane is available",
+			},
+			map[string]interface{}{
+				"type":    "ClusterVersionProgressing",
+				"status":  "False",
+				"message": "Cluster version is 4.13.7",
+			},
+			map[string]interface{}{
+				"type":    "Progressing",
+				"status":  "True",
+				"message": "HostedCluster is at expected version",
+			},
+		}),
+		getManagedCluster(),
+	)
+
+	assert.NotNil(
+		t,
+		DetachAndMonitor(dynfake, ClusterName, clusterCurator),
+		"err is not nil, when user is destroying AWS HC",
+	)
+}
+
+func TestDetachAndMonitorKubeVirt(t *testing.T) {
+	clusterCurator := getUpgradeClusterCurator("4.13.7")
+	dynfake := dynfake.NewSimpleDynamicClient(
+		runtime.NewScheme(),
+		getHostedCluster("KubeVirt", []interface{}{
+			map[string]interface{}{
+				"type":    "Degraded",
+				"status":  "False",
+				"message": "The hosted cluster is not degraded",
+			},
+			map[string]interface{}{
+				"type":    "ClusterVersionAvailable",
+				"status":  "True",
+				"message": "Done applying 4.13.7",
+			},
+			map[string]interface{}{
+				"type":    "Available",
+				"status":  "True",
+				"message": "The hosted control plane is available",
+			},
+			map[string]interface{}{
+				"type":    "ClusterVersionProgressing",
+				"status":  "False",
+				"message": "Cluster version is 4.13.7",
+			},
+			map[string]interface{}{
+				"type":    "Progressing",
+				"status":  "True",
+				"message": "HostedCluster is at expected version",
+			},
+		}),
+		getManagedCluster(),
+	)
+
+	assert.Nil(
+		t,
+		DetachAndMonitor(dynfake, ClusterName, clusterCurator),
+		"err is nil, when user is destroying KubeVirt HC",
+	)
+}

--- a/pkg/jobs/rbac/rbac.go
+++ b/pkg/jobs/rbac/rbac.go
@@ -256,7 +256,8 @@ func ApplyRBAC(kubeset kubernetes.Interface, namespace string) error {
 
 func ApplyRBACHypershift(kubeset kubernetes.Interface, namespace string, curatorNamespace string) error {
 	klog.V(2).Info("Check if RoleBinding curator exists in namespace " + namespace)
-	if _, err := kubeset.RbacV1().RoleBindings(namespace).Get(context.TODO(), "curator", v1.GetOptions{}); k8serrors.IsNotFound(err) {
+	if _, err := kubeset.RbacV1().RoleBindings(namespace).Get(
+		context.TODO(), "curator", v1.GetOptions{}); k8serrors.IsNotFound(err) {
 		klog.V(2).Info(" Creating RoleBinding curator in namespace " + namespace)
 		_, err = kubeset.RbacV1().RoleBindings(namespace).Create(
 			context.TODO(), getRoleBinding(curatorNamespace), v1.CreateOptions{})
@@ -267,7 +268,8 @@ func ApplyRBACHypershift(kubeset kubernetes.Interface, namespace string, curator
 	}
 
 	klog.V(2).Info("Check if ClusterRole curator-crb exists")
-	if _, err := kubeset.RbacV1().ClusterRoleBindings().Get(context.TODO(), "curator-crb", v1.GetOptions{}); k8serrors.IsNotFound(err) {
+	if _, err := kubeset.RbacV1().ClusterRoleBindings().Get(
+		context.TODO(), "curator-crb", v1.GetOptions{}); k8serrors.IsNotFound(err) {
 		klog.V(2).Info(" Creating ClusterRoleBinding curator-crb")
 		_, err = kubeset.RbacV1().ClusterRoleBindings().Create(
 			context.TODO(), getClusterRoleBinding(curatorNamespace), v1.CreateOptions{})

--- a/pkg/jobs/rbac/rbac.go
+++ b/pkg/jobs/rbac/rbac.go
@@ -231,16 +231,6 @@ func ApplyRBAC(kubeset kubernetes.Interface, namespace string) error {
 		klog.V(0).Info(" Created serviceAccount ✓")
 	}
 
-	// klog.V(2).Info("Check if Role curator exists")
-	// if _, err := kubeset.RbacV1().Roles(namespace).Get(context.TODO(), "curator", v1.GetOptions{}); err != nil {
-	// 	klog.V(2).Info(" Creating Role curator")
-	// 	_, err = kubeset.RbacV1().Roles(namespace).Create(context.TODO(), getRole(namespace), v1.CreateOptions{})
-	// 	if err != nil {
-	// 		return err
-	// 	}
-	// 	klog.V(0).Info(" Created Role ✓")
-	// }
-
 	klog.V(2).Info("Check if ClusterRole curator exists")
 	if _, err := kubeset.RbacV1().ClusterRoles().Get(context.TODO(), "curator", v1.GetOptions{}); err != nil {
 		klog.V(2).Info(" Creating ClusterRole curator")
@@ -267,7 +257,8 @@ func ApplyRBACHypershift(kubeset kubernetes.Interface, namespace string, curator
 	klog.V(2).Info("Check if RoleBinding cluster-installer exists in namespace " + namespace)
 	if _, err := kubeset.RbacV1().RoleBindings(namespace).Get(context.TODO(), "curator", v1.GetOptions{}); err != nil {
 		klog.V(2).Info(" Creating RoleBinding curator in namespace " + namespace)
-		_, err = kubeset.RbacV1().RoleBindings(namespace).Create(context.TODO(), getRoleBinding(curatorNamespace), v1.CreateOptions{})
+		_, err = kubeset.RbacV1().RoleBindings(namespace).Create(
+			context.TODO(), getRoleBinding(curatorNamespace), v1.CreateOptions{})
 		if err != nil {
 			return err
 		}
@@ -277,7 +268,8 @@ func ApplyRBACHypershift(kubeset kubernetes.Interface, namespace string, curator
 	klog.V(2).Info("Check if ClusterRole curator-crb exists")
 	if _, err := kubeset.RbacV1().ClusterRoleBindings().Get(context.TODO(), "curator-crb", v1.GetOptions{}); err != nil {
 		klog.V(2).Info(" Creating ClusterRoleBinding curator-crb")
-		_, err = kubeset.RbacV1().ClusterRoleBindings().Create(context.TODO(), getClusterRoleBinding(curatorNamespace), v1.CreateOptions{})
+		_, err = kubeset.RbacV1().ClusterRoleBindings().Create(
+			context.TODO(), getClusterRoleBinding(curatorNamespace), v1.CreateOptions{})
 		if err != nil {
 			return err
 		}

--- a/pkg/jobs/rbac/rbac.go
+++ b/pkg/jobs/rbac/rbac.go
@@ -256,7 +256,8 @@ func ApplyRBAC(kubeset kubernetes.Interface, namespace string) error {
 
 func ApplyRBACHypershift(kubeset kubernetes.Interface, namespace string, curatorNamespace string) error {
 	klog.V(2).Info("Check if RoleBinding curator exists in namespace " + namespace)
-	if _, err := kubeset.RbacV1().RoleBindings(namespace).Get(
+	var err error
+	if _, err = kubeset.RbacV1().RoleBindings(namespace).Get(
 		context.TODO(), "curator", v1.GetOptions{}); k8serrors.IsNotFound(err) {
 		klog.V(2).Info(" Creating RoleBinding curator in namespace " + namespace)
 		_, err = kubeset.RbacV1().RoleBindings(namespace).Create(
@@ -265,10 +266,12 @@ func ApplyRBACHypershift(kubeset kubernetes.Interface, namespace string, curator
 			return err
 		}
 		klog.V(0).Info(" Created RoleBinding in cluster namespace ✓")
+	} else if err != nil {
+		return err
 	}
 
 	klog.V(2).Info("Check if ClusterRole curator-crb exists")
-	if _, err := kubeset.RbacV1().ClusterRoleBindings().Get(
+	if _, err = kubeset.RbacV1().ClusterRoleBindings().Get(
 		context.TODO(), "curator-crb", v1.GetOptions{}); k8serrors.IsNotFound(err) {
 		klog.V(2).Info(" Creating ClusterRoleBinding curator-crb")
 		_, err = kubeset.RbacV1().ClusterRoleBindings().Create(
@@ -278,7 +281,7 @@ func ApplyRBACHypershift(kubeset kubernetes.Interface, namespace string, curator
 		}
 		klog.V(0).Info(" Created ClusterRoleBinding ✓")
 	}
-	return nil
+	return err
 }
 
 func ExtendClusterInstallerRole(kubeset kubernetes.Interface, namespace string) error {

--- a/pkg/jobs/rbac/rbac.go
+++ b/pkg/jobs/rbac/rbac.go
@@ -11,6 +11,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -254,8 +255,8 @@ func ApplyRBAC(kubeset kubernetes.Interface, namespace string) error {
 }
 
 func ApplyRBACHypershift(kubeset kubernetes.Interface, namespace string, curatorNamespace string) error {
-	klog.V(2).Info("Check if RoleBinding cluster-installer exists in namespace " + namespace)
-	if _, err := kubeset.RbacV1().RoleBindings(namespace).Get(context.TODO(), "curator", v1.GetOptions{}); err != nil {
+	klog.V(2).Info("Check if RoleBinding curator exists in namespace " + namespace)
+	if _, err := kubeset.RbacV1().RoleBindings(namespace).Get(context.TODO(), "curator", v1.GetOptions{}); k8serrors.IsNotFound(err) {
 		klog.V(2).Info(" Creating RoleBinding curator in namespace " + namespace)
 		_, err = kubeset.RbacV1().RoleBindings(namespace).Create(
 			context.TODO(), getRoleBinding(curatorNamespace), v1.CreateOptions{})
@@ -266,7 +267,7 @@ func ApplyRBACHypershift(kubeset kubernetes.Interface, namespace string, curator
 	}
 
 	klog.V(2).Info("Check if ClusterRole curator-crb exists")
-	if _, err := kubeset.RbacV1().ClusterRoleBindings().Get(context.TODO(), "curator-crb", v1.GetOptions{}); err != nil {
+	if _, err := kubeset.RbacV1().ClusterRoleBindings().Get(context.TODO(), "curator-crb", v1.GetOptions{}); k8serrors.IsNotFound(err) {
 		klog.V(2).Info(" Creating ClusterRoleBinding curator-crb")
 		_, err = kubeset.RbacV1().ClusterRoleBindings().Create(
 			context.TODO(), getClusterRoleBinding(curatorNamespace), v1.CreateOptions{})

--- a/pkg/jobs/utils/helpers.go
+++ b/pkg/jobs/utils/helpers.go
@@ -134,7 +134,11 @@ func RecordCuratorJob(clusterName, containerName string) error {
 	return patchDyn(dynset, clusterName, containerName, CurrentCuratorJob)
 }
 
-func RecordCuratorJobName(client clientv1.Client, clusterName string, clusterNamespace string, curatorJobName string) error {
+func RecordCuratorJobName(
+	client clientv1.Client,
+	clusterName string,
+	clusterNamespace string,
+	curatorJobName string) error {
 	cc, err := GetClusterCurator(client, clusterName, clusterNamespace)
 	if err != nil {
 		return err
@@ -287,7 +291,10 @@ func RecordFailedCuratorStatusCondition(
 		message)
 }
 
-func GetClusterCurator(client clientv1.Client, clusterName string, clusterNamespace string) (*clustercuratorv1.ClusterCurator, error) {
+func GetClusterCurator(
+	client clientv1.Client,
+	clusterName string,
+	clusterNamespace string) (*clustercuratorv1.ClusterCurator, error) {
 
 	curator := &clustercuratorv1.ClusterCurator{}
 
@@ -490,7 +497,11 @@ func parseVersionInfo(msg string) (channel, upstream string, semversion semver.V
 	return channel, upstream, semversion, nil
 }
 
-func GetClusterType(hiveset hiveclient.Interface, dc dynamic.Interface, clusterName string, clusterNamespace string) (string, error) {
+func GetClusterType(
+	hiveset hiveclient.Interface,
+	dc dynamic.Interface,
+	clusterName string,
+	clusterNamespace string) (string, error) {
 	// shortcut for Hypershift cluster
 	if clusterName != clusterNamespace {
 		return HypershiftClusterType, nil
@@ -502,7 +513,8 @@ func GetClusterType(hiveset hiveclient.Interface, dc dynamic.Interface, clusterN
 		return StandaloneClusterType, nil
 	}
 
-	hostedCluster, hcErr := dc.Resource(HCGVR).Namespace(clusterNamespace).Get(context.TODO(), clusterName, v1.GetOptions{})
+	hostedCluster, hcErr := dc.Resource(HCGVR).Namespace(clusterNamespace).Get(
+		context.TODO(), clusterName, v1.GetOptions{})
 	if hcErr == nil && hostedCluster != nil {
 		return HypershiftClusterType, nil
 	}

--- a/pkg/jobs/utils/helpers_test.go
+++ b/pkg/jobs/utils/helpers_test.go
@@ -153,6 +153,7 @@ func TestRecordCuratedStatusCondition(t *testing.T) {
 		recordCuratedStatusCondition(
 			client,
 			ClusterName,
+			ClusterName,
 			CurrentAnsibleJob,
 			v1.ConditionTrue,
 			JobHasFinished,
@@ -179,6 +180,7 @@ func TestRecordCurrentStatusConditionNoResource(t *testing.T) {
 
 	err := RecordCurrentStatusCondition(
 		client,
+		ClusterName,
 		ClusterName,
 		CurrentAnsibleJob,
 		v1.ConditionTrue,
@@ -648,4 +650,27 @@ func TestNeedToUpgrade(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetMonitorAttempts(t *testing.T) {
+	attempts := GetMonitorAttempts("", &clustercuratorv1.ClusterCurator{})
+	assert.Equal(t, 150, attempts)
+
+	attempts = GetMonitorAttempts("provision", &clustercuratorv1.ClusterCurator{
+		Spec: clustercuratorv1.ClusterCuratorSpec{
+			Install: clustercuratorv1.Hooks{
+				JobMonitorTimeout: 6,
+			},
+		},
+	})
+	assert.Equal(t, 180, attempts)
+
+	attempts = GetMonitorAttempts("uninstall", &clustercuratorv1.ClusterCurator{
+		Spec: clustercuratorv1.ClusterCuratorSpec{
+			Destroy: clustercuratorv1.Hooks{
+				JobMonitorTimeout: 15,
+			},
+		},
+	})
+	assert.Equal(t, 450, attempts)
 }

--- a/pkg/jobs/utils/helpers_test.go
+++ b/pkg/jobs/utils/helpers_test.go
@@ -196,7 +196,7 @@ func TestGetClusterCurator(t *testing.T) {
 
 	client := clientfake.NewFakeClientWithScheme(s, cc)
 
-	_, err := GetClusterCurator(client, ClusterName)
+	_, err := GetClusterCurator(client, ClusterName, ClusterName)
 	assert.Nil(t, err, "err is nil, when ClusterCurator resource is retrieved")
 }
 
@@ -207,7 +207,7 @@ func TestGetClusterCuratorNoResource(t *testing.T) {
 
 	client := clientfake.NewFakeClientWithScheme(s)
 
-	cc, err := GetClusterCurator(client, ClusterName)
+	cc, err := GetClusterCurator(client, ClusterName, ClusterName)
 	assert.Nil(t, cc, "cc is nil, when ClusterCurator resource is not found")
 	assert.NotNil(t, err, "err is not nil, when ClusterCurator is not found")
 	t.Logf("err: %v", err)
@@ -221,7 +221,7 @@ func TestRecordCuratorJobName(t *testing.T) {
 	s.AddKnownTypes(CCGVR.GroupVersion(), &clustercuratorv1.ClusterCurator{})
 	client := clientfake.NewFakeClientWithScheme(s, cc)
 
-	err := RecordCuratorJobName(client, ClusterName, "my-job-ABCDE")
+	err := RecordCuratorJobName(client, ClusterName, ClusterName, "my-job-ABCDE")
 
 	assert.Nil(t, err, "err nil, when Job name written to ClusterCurator.Spec.curatorJob")
 
@@ -233,7 +233,7 @@ func TestRecordCuratorJobNameInvalidCurator(t *testing.T) {
 	s.AddKnownTypes(CCGVR.GroupVersion(), &clustercuratorv1.ClusterCurator{})
 	client := clientfake.NewFakeClientWithScheme(s)
 
-	err := RecordCuratorJobName(client, ClusterName, "my-job-ABCDE")
+	err := RecordCuratorJobName(client, ClusterName, ClusterName, "my-job-ABCDE")
 
 	assert.NotNil(t, err, "err nil, when Job name written to ClusterCurator.Spec.curatorJob")
 	t.Logf("Detected Errror: %v", err.Error())


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-6494

- Add support for Hypershift clusters AWS, Agent, and KubeVirt
- Supported operations `install`, `upgrade`, `destroy`
- AWS doesn't support `destroy`
- `ClusterCurator` CR need to be created in the same namespace as `HostedCluster` this is different than standalone OCP where the `ClusterCurator` CR need to be in the namespace with the cluster name
- Other than that all usage is same as standalone OCP, `ClusterCurator` will auto-detect between Hosted and Standalone clusters