### PR TITLE
ACM-9123 Fix HostedCluster permission issue for users going from 2.8 to 2.9

### DIFF
--- a/pkg/jobs/utils/helpers.go
+++ b/pkg/jobs/utils/helpers.go
@@ -520,7 +520,9 @@ func GetClusterType(
 		context.TODO(), clusterName, v1.GetOptions{})
 	if hcErr == nil && hostedCluster != nil {
 		return HypershiftClusterType, nil
-	} else if !strings.Contains(hcErr.Error(), "not found") {
+	} else if !strings.Contains(hcErr.Error(), "not found") &&
+		!strings.Contains(hcErr.Error(), "could not find") &&
+		!strings.Contains(hcErr.Error(), "is forbidden") {
 		return "", hcErr
 	}
 


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-9123

```
DesiredCuration: upgrade Version (4.12.45;;) Failed - hostedclusters.hypershift.openshift.io \"mytestcluster45\" is forbidden: User \"system:serviceaccount:mytestcluster45:cluster-installer\" cannot get resource \"hostedclusters\" in API group \"hypershift.openshift.io\" in the namespace \"mytestcluster45\""
```

- Fix HostedCluster permission issue for users going from 2.8 to 2.9
- Ignore HostedCluster CRD not found error if Hypershift operator is not installed
- Ignore `is forbidden` permissions error