### PR TITLE
Push Labels from curator CR to curator pods

### DIFF
--- a/pkg/controller/launcher/job.go
+++ b/pkg/controller/launcher/job.go
@@ -325,7 +325,9 @@ func getBatchJob(
 			Resources: resourceSettings,
 		})
 	}
+	newJob.Spec.Template.Labels = curator.Labels
 	return newJob
+
 }
 
 func (I *Launcher) CreateJob() error {


### PR DESCRIPTION
Curator pods were lacking with custom/generic labels, this makes it hard to target the curator pods with network policies.