### PR TITLE
Remove the dependency to stolostron lib-go.

### DIFF
--- a/cmd/curator/curator.go
+++ b/cmd/curator/curator.go
@@ -20,7 +20,6 @@ import (
 	"github.com/stolostron/cluster-curator-controller/pkg/jobs/importer"
 	"github.com/stolostron/cluster-curator-controller/pkg/jobs/secrets"
 	"github.com/stolostron/cluster-curator-controller/pkg/jobs/utils"
-	"github.com/stolostron/library-go/pkg/config"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
@@ -56,7 +55,7 @@ func main() {
 	}
 
 	// Build a connection to the Hub OCP
-	config, err := config.LoadConfig("", "", "")
+	config, err := rest.InClusterConfig()
 	utils.CheckError(err)
 
 	client, err := utils.GetClient()

--- a/cmd/curator/curator_test.go
+++ b/cmd/curator/curator_test.go
@@ -17,7 +17,6 @@ import (
 	clustercuratorv1 "github.com/stolostron/cluster-curator-controller/pkg/api/v1beta1"
 	"github.com/stolostron/cluster-curator-controller/pkg/jobs/utils"
 	managedclusterviewv1beta1 "github.com/stolostron/cluster-lifecycle-api/view/v1beta1"
-	"github.com/stolostron/library-go/pkg/config"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -462,7 +461,7 @@ func TestHypershiftActivate(t *testing.T) {
 		getNodepool(NodepoolName, ClusterNamespace, ClusterName),
 	).Build()
 
-	config, _ := config.LoadConfig("", "", "")
+	config, _ := rest.InClusterConfig()
 
 	curatorRun(config, client, ClusterNamespace, ClusterName)
 }
@@ -486,7 +485,7 @@ func TestHypershiftMonitor(t *testing.T) {
 		getNodepool(NodepoolName, ClusterNamespace, ClusterName),
 	).Build()
 
-	config, _ := config.LoadConfig("", "", "")
+	config, _ := rest.InClusterConfig()
 
 	curatorRun(config, client, ClusterNamespace, ClusterName)
 }
@@ -510,7 +509,7 @@ func TestHypershiftDestroyCluster(t *testing.T) {
 		getNodepool(NodepoolName, ClusterNamespace, ClusterName),
 	).Build()
 
-	config, _ := config.LoadConfig("", "", "")
+	config, _ := rest.InClusterConfig()
 
 	curatorRun(config, client, ClusterNamespace, ClusterName)
 }
@@ -534,7 +533,7 @@ func TestHypershiftMonitorDestroy(t *testing.T) {
 		getNodepool(NodepoolName, ClusterNamespace, ClusterName),
 	).Build()
 
-	config, _ := config.LoadConfig("", "", "")
+	config, _ := rest.InClusterConfig()
 
 	curatorRun(config, client, ClusterNamespace, ClusterName)
 }
@@ -558,7 +557,7 @@ func TestHypershiftUpgradeCluster(t *testing.T) {
 		getNodepool(NodepoolName, ClusterNamespace, ClusterName),
 	).Build()
 
-	config, _ := config.LoadConfig("", "", "")
+	config, _ := rest.InClusterConfig()
 
 	curatorRun(config, client, ClusterNamespace, ClusterName)
 }
@@ -582,7 +581,7 @@ func TestHypershiftMonitorUpgrade(t *testing.T) {
 		getNodepool(NodepoolName, ClusterNamespace, ClusterName),
 	).Build()
 
-	config, _ := config.LoadConfig("", "", "")
+	config, _ := rest.InClusterConfig()
 
 	curatorRun(config, client, ClusterNamespace, ClusterName)
 }
@@ -604,7 +603,7 @@ func TestEUSIntermediateUpgrade(t *testing.T) {
 		getEUSUpgradeClusterCurator(),
 	).Build()
 
-	config, _ := config.LoadConfig("", "", "")
+	config, _ := rest.InClusterConfig()
 
 	curatorRun(config, client, ClusterName, ClusterName)
 }
@@ -626,7 +625,7 @@ func TestEUSFinalUpgrade(t *testing.T) {
 		getEUSUpgradeClusterCurator(),
 	).Build()
 
-	config, _ := config.LoadConfig("", "", "")
+	config, _ := rest.InClusterConfig()
 
 	curatorRun(config, client, ClusterName, ClusterName)
 }
@@ -649,7 +648,7 @@ func TestEUSMonitorUpgrade(t *testing.T) {
 		getEUSClusterVersionManagedClusterView(),
 	).Build()
 
-	config, _ := config.LoadConfig("", "", "")
+	config, _ := rest.InClusterConfig()
 
 	curatorRun(config, client, ClusterName, ClusterName)
 }

--- a/controllers/scale_controller_test.go
+++ b/controllers/scale_controller_test.go
@@ -10,11 +10,11 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/stolostron/library-go/pkg/config"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	managedclusterclient "open-cluster-management.io/api/client/cluster/clientset/versioned"
 	managedclusterv1 "open-cluster-management.io/api/cluster/v1"
 )
@@ -86,7 +86,7 @@ func TestCreateControllerScale(t *testing.T) {
 
 	skipShort(t)
 
-	config, err := config.LoadConfig("", "", "")
+	config, err := rest.InClusterConfig()
 	if err != nil {
 		t.Fatal("Could not load Kube Config")
 	}
@@ -122,7 +122,7 @@ func TestDeleteManagedClusters(t *testing.T) {
 
 	skipShort(t)
 
-	config, err := config.LoadConfig("", "", "")
+	config, err := rest.InClusterConfig()
 	assert.Nil(t, err, "err nil, when kube config is found")
 
 	mcset, err := managedclusterclient.NewForConfig(config)
@@ -153,7 +153,7 @@ func TestRemoveFinalizerForManagedClusters(t *testing.T) {
 
 	skipShort(t)
 
-	config, err := config.LoadConfig("", "", "")
+	config, err := rest.InClusterConfig()
 	assert.Nil(t, err, "err nil, when kube config is found")
 
 	mcset, err := managedclusterclient.NewForConfig(config)

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/openshift/api v3.9.1-0.20191111211345-a27ff30ebf09+incompatible
 	github.com/openshift/hive/apis v0.0.0-20240719225702-cddd4f9551ea
 	github.com/stolostron/cluster-lifecycle-api v0.0.0-20220714081119-eae2fe1f05fd
-	github.com/stolostron/library-go v0.0.0-20220727113621-f74e0852408a
 	github.com/stretchr/testify v1.8.4
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1067,8 +1067,6 @@ github.com/stolostron/ansiblejob-go-lib v0.1.12 h1:B1JS4cTctTNDkd4NrUEcRBS9JovJN
 github.com/stolostron/ansiblejob-go-lib v0.1.12/go.mod h1:dDL15yXQUna2cVZwjgnQ/HZ95deXgI4Uj8/djY4A5o4=
 github.com/stolostron/cluster-lifecycle-api v0.0.0-20220714081119-eae2fe1f05fd h1:TitMXyGY/ld+hS6kjdHwcdR+Pl2UrtO812ehBTcu34Q=
 github.com/stolostron/cluster-lifecycle-api v0.0.0-20220714081119-eae2fe1f05fd/go.mod h1:pNeVzujoHsTHDloNHVfp1QPYlQy8MkXMuuZme96/x8M=
-github.com/stolostron/library-go v0.0.0-20220727113621-f74e0852408a h1:H//pS8d6Oi4uYjGNFxhyA3mg/VVWO2FEIjpln6m5ckE=
-github.com/stolostron/library-go v0.0.0-20220727113621-f74e0852408a/go.mod h1:BbQ8BihpRXW6OaK6ZD1g28IkS8T6/DlYag9nJvivuq0=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=

--- a/pkg/jobs/utils/helpers.go
+++ b/pkg/jobs/utils/helpers.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/blang/semver/v4"
-	"github.com/stolostron/library-go/pkg/config"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -33,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	clientv1 "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -174,7 +174,7 @@ func patchDyn(dynset dynamic.Interface, clusterName string, containerName string
 
 func GetDynset(dynset dynamic.Interface) (dynamic.Interface, error) {
 
-	config, err := config.LoadConfig("", "", "")
+	config, err := rest.InClusterConfig()
 	if err != nil {
 		return nil, err
 	}
@@ -184,7 +184,7 @@ func GetDynset(dynset dynamic.Interface) (dynamic.Interface, error) {
 
 func GetClient() (clientv1.Client, error) {
 
-	config, err := config.LoadConfig("", "", "")
+	config, err := rest.InClusterConfig()
 	if err != nil {
 		return nil, err
 	}
@@ -204,7 +204,7 @@ func GetClient() (clientv1.Client, error) {
 
 func GetKubeset() (kubernetes.Interface, error) {
 
-	config, err := config.LoadConfig("", "", "")
+	config, err := rest.InClusterConfig()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The https://github.com/stolostron/library-go has been inactive for years, comfirmed with the repo owner, the repo is not been maintained in the furture.

Teh curator repo only use `LoadConfig` , but the only pattern is `LoadConfig("","","")`. So we can replace it with the `rest.InClusterConfig()` directly.