### PR TITLE
Fix UBI version skew

### DIFF
--- a/Dockerfile.prow
+++ b/Dockerfile.prow
@@ -8,7 +8,7 @@ RUN make compile-curator
 #RUN go build -o build/_output/curator ./pkg/jobs/curator.go
 #RUN go build -o build/_output/cluster-curator-controller ./pkg/controller/controller.go
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 ENV USER_UID=1001
 

--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.22 as builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.22 as builder
 
 WORKDIR /go/src/github.com/stolostron/cluster-curator-controller
 COPY . .
@@ -8,7 +8,7 @@ RUN make compile-curator
 #RUN go build -o build/_output/curator ./pkg/jobs/curator.go
 #RUN go build -o build/_output/cluster-curator-controller ./pkg/controller/controller.go
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 ENV USER_UID=1001
 


### PR DESCRIPTION
The Go 1.22 builder image is built with UBI9, so passing the binary to a UBI8 image with CGO enabled is broken.