### PR TITLE
ACM-22079 Initial non-recommended image digest feature

### DIFF
--- a/cmd/curator/curator.go
+++ b/cmd/curator/curator.go
@@ -55,7 +55,7 @@ func main() {
 	}
 
 	// Build a connection to the Hub OCP
-	config, err := utils.LoadConfig("", "", "")
+	config, err := utils.LoadConfig("", "")
 	utils.CheckError(err)
 
 	client, err := utils.GetClient()

--- a/cmd/curator/curator.go
+++ b/cmd/curator/curator.go
@@ -55,7 +55,7 @@ func main() {
 	}
 
 	// Build a connection to the Hub OCP
-	config, err := utils.LoadConfig("", "")
+	config, err := utils.LoadConfig()
 	utils.CheckError(err)
 
 	client, err := utils.GetClient()

--- a/cmd/curator/curator.go
+++ b/cmd/curator/curator.go
@@ -55,7 +55,7 @@ func main() {
 	}
 
 	// Build a connection to the Hub OCP
-	config, err := rest.InClusterConfig()
+	config, err := utils.LoadConfig("", "", "")
 	utils.CheckError(err)
 
 	client, err := utils.GetClient()

--- a/pkg/jobs/hive/hive_test.go
+++ b/pkg/jobs/hive/hive_test.go
@@ -1669,3 +1669,246 @@ func TestEUSFinalUpgrade(t *testing.T) {
 		EUSUpgradeCluster(client, ClusterName, clustercurator, false),
 		"EUS Final Upgrade started successfully")
 }
+
+func TestUpgradeClusterForceUpgradeWithImageDigest(t *testing.T) {
+
+	s := scheme.Scheme
+	s.AddKnownTypes(clustercuratorv1.SchemeBuilder.GroupVersion, &clustercuratorv1.ClusterCurator{})
+	s.AddKnownTypes(managedclusterinfov1beta1.SchemeGroupVersion, &managedclusterinfov1beta1.ManagedClusterInfo{})
+	s.AddKnownTypes(managedclusteractionv1beta1.SchemeGroupVersion, &managedclusteractionv1beta1.ManagedClusterAction{})
+	s.AddKnownTypes(managedclusterviewv1beta1.SchemeGroupVersion, &managedclusterviewv1beta1.ManagedClusterView{})
+
+	clustercurator := &clustercuratorv1.ClusterCurator{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      ClusterName,
+			Namespace: ClusterName,
+			Annotations: map[string]string{
+				"cluster.open-cluster-management.io/upgrade-allow-not-recommended-versions": "true",
+			},
+		},
+		Spec: clustercuratorv1.ClusterCuratorSpec{
+			DesiredCuration: "upgrade",
+			Upgrade: clustercuratorv1.UpgradeHooks{
+				DesiredUpdate: "4.5.10",
+			},
+		},
+	}
+
+	currentClusterVersion := &clusterversionv1.ClusterVersion{
+		TypeMeta: v1.TypeMeta{
+			APIVersion: "config.openshift.io/v1",
+			Kind:       "ClusterVersion",
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name: "version",
+		},
+		Spec: clusterversionv1.ClusterVersionSpec{
+			Channel:   "stable-4.5",
+			ClusterID: "201ad26c-67d6-416a",
+			Upstream:  "https://api.openshift.com/api",
+			DesiredUpdate: &clusterversionv1.Update{
+				Image:   "quay.io/openshift-release-dev/ocp-release@sha256:71e158c6173ad6aa6e356c119a87459196bbe70e89c0db1e35c1f63a87d90676",
+				Version: "4.5.10",
+			},
+		},
+		Status: clusterversionv1.ClusterVersionStatus{
+			AvailableUpdates: []clusterversionv1.Release{
+				{
+					Version: "4.5.10",
+					Image:   "quay.io/openshift-release-dev/ocp-release@sha256:71e158c6173ad6aa6e356c119a87459196bbe70e89c0db1e35c1f63a87d90676",
+				},
+			},
+			ConditionalUpdates: []clusterversionv1.ConditionalUpdate{
+				{
+					Release: clusterversionv1.Release{
+						Channels: []string{
+							"stable-4.5",
+						},
+						Image:   "quay.io/openshift-release-dev/ocp-release@sha256:71e158c6173ad6aa6e356c119a87459196bbe70e89c0db1e35c1f63a87d90676",
+						URL:     "'https://access.redhat.com/errata/RHBA-2025:8116",
+						Version: "4.5.10",
+					},
+				},
+			},
+		},
+	}
+
+	b, _ := json.Marshal(currentClusterVersion)
+
+	client := clientfake.NewClientBuilder().WithRuntimeObjects([]runtime.Object{
+		clustercurator, getManagedClusterInfo(),
+	}...).WithScheme(s).Build()
+
+	go func() {
+		for i := 0; i < 10; i++ {
+			time.Sleep(1 * time.Second)
+			resultmcview := managedclusterviewv1beta1.ManagedClusterView{}
+			err := client.Get(context.TODO(), types.NamespacedName{
+				Namespace: ClusterName,
+				Name:      ClusterName,
+			}, &resultmcview)
+			if err != nil {
+				klog.Error("failed to get managedClusterview.", err)
+				continue
+			}
+			resultmcview.Status.Result.Raw = b
+			err = client.Update(context.TODO(), &resultmcview)
+			if err != nil {
+				klog.Error("failed to update managedClusterview.", err)
+				continue
+			}
+			updatedresultmcview := managedclusterviewv1beta1.ManagedClusterView{}
+			err = client.Get(context.TODO(), types.NamespacedName{
+				Namespace: ClusterName,
+				Name:      ClusterName,
+			}, &updatedresultmcview)
+			if err != nil {
+				klog.Error("failed to get managedClusterview.", err)
+				continue
+			}
+			if updatedresultmcview.Status.Result.Raw != nil {
+				break
+			}
+		}
+	}()
+
+	go func() {
+		for i := 0; i < 10; i++ {
+			time.Sleep(1 * time.Second)
+			resultmca := managedclusteractionv1beta1.ManagedClusterAction{}
+			err := client.Get(context.TODO(), types.NamespacedName{
+				Namespace: ClusterName,
+				Name:      ClusterName,
+			}, &resultmca)
+
+			if err == nil {
+				patch := []byte(`{"status":{"conditions":[
+							{
+								"lastTransitionTime": "2021-04-28T16:19:38Z",
+								"message": " Resource action is done.",
+								"reason": "ActionDone",
+								"status": "True",
+								"type": "Completed"
+							}]}}`)
+				client.Patch(context.Background(), &resultmca, clientv1.RawPatch(types.MergePatchType, patch))
+				break
+			}
+		}
+	}()
+
+	assert.Nil(t, UpgradeCluster(client, ClusterName, clustercurator), "Upgrade started successfully to non-recommended version with image digest")
+}
+
+func TestUpgradeClusterForceUpgradeWithImageDigestInAvailableList(t *testing.T) {
+
+	s := scheme.Scheme
+	s.AddKnownTypes(clustercuratorv1.SchemeBuilder.GroupVersion, &clustercuratorv1.ClusterCurator{})
+	s.AddKnownTypes(managedclusterinfov1beta1.SchemeGroupVersion, &managedclusterinfov1beta1.ManagedClusterInfo{})
+	s.AddKnownTypes(managedclusteractionv1beta1.SchemeGroupVersion, &managedclusteractionv1beta1.ManagedClusterAction{})
+	s.AddKnownTypes(managedclusterviewv1beta1.SchemeGroupVersion, &managedclusterviewv1beta1.ManagedClusterView{})
+
+	clustercurator := &clustercuratorv1.ClusterCurator{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      ClusterName,
+			Namespace: ClusterName,
+			Annotations: map[string]string{
+				"cluster.open-cluster-management.io/upgrade-allow-not-recommended-versions": "true",
+			},
+		},
+		Spec: clustercuratorv1.ClusterCuratorSpec{
+			DesiredCuration: "upgrade",
+			Upgrade: clustercuratorv1.UpgradeHooks{
+				DesiredUpdate: "4.5.10",
+			},
+		},
+	}
+
+	currentClusterVersion := &clusterversionv1.ClusterVersion{
+		TypeMeta: v1.TypeMeta{
+			APIVersion: "config.openshift.io/v1",
+			Kind:       "ClusterVersion",
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name: "version",
+		},
+		Spec: clusterversionv1.ClusterVersionSpec{
+			Channel:   "stable-4.5",
+			ClusterID: "201ad26c-67d6-416a",
+			Upstream:  "https://api.openshift.com/api",
+		},
+		Status: clusterversionv1.ClusterVersionStatus{
+			AvailableUpdates: []clusterversionv1.Release{
+				{
+					Version: "4.5.10",
+					Image:   "quay.io/openshift-release-dev/ocp-release@sha256:71e158c6173ad6aa6e356c119a87459196bbe70e89c0db1e35c1f63a87d90676",
+				},
+			},
+		},
+	}
+
+	b, _ := json.Marshal(currentClusterVersion)
+
+	client := clientfake.NewClientBuilder().WithRuntimeObjects([]runtime.Object{
+		clustercurator, getManagedClusterInfo(),
+	}...).WithScheme(s).Build()
+
+	go func() {
+		for i := 0; i < 10; i++ {
+			time.Sleep(1 * time.Second)
+			resultmcview := managedclusterviewv1beta1.ManagedClusterView{}
+			err := client.Get(context.TODO(), types.NamespacedName{
+				Namespace: ClusterName,
+				Name:      ClusterName,
+			}, &resultmcview)
+			if err != nil {
+				klog.Error("failed to get managedClusterview.", err)
+				continue
+			}
+			resultmcview.Status.Result.Raw = b
+			err = client.Update(context.TODO(), &resultmcview)
+			if err != nil {
+				klog.Error("failed to update managedClusterview.", err)
+				continue
+			}
+			updatedresultmcview := managedclusterviewv1beta1.ManagedClusterView{}
+			err = client.Get(context.TODO(), types.NamespacedName{
+				Namespace: ClusterName,
+				Name:      ClusterName,
+			}, &updatedresultmcview)
+			if err != nil {
+				klog.Error("failed to get managedClusterview.", err)
+				continue
+			}
+			if updatedresultmcview.Status.Result.Raw != nil {
+				break
+			}
+		}
+	}()
+
+	go func() {
+		for i := 0; i < 10; i++ {
+			time.Sleep(1 * time.Second)
+			resultmca := managedclusteractionv1beta1.ManagedClusterAction{}
+			err := client.Get(context.TODO(), types.NamespacedName{
+				Namespace: ClusterName,
+				Name:      ClusterName,
+			}, &resultmca)
+
+			if err == nil {
+				patch := []byte(`{"status":{"conditions":[
+							{
+								"lastTransitionTime": "2021-04-28T16:19:38Z",
+								"message": " Resource action is done.",
+								"reason": "ActionDone",
+								"status": "True",
+								"type": "Completed"
+							}]}}`)
+				client.Patch(context.Background(), &resultmca, clientv1.RawPatch(types.MergePatchType, patch))
+				break
+			}
+		}
+	}()
+
+	assert.Nil(t, UpgradeCluster(client, ClusterName, clustercurator),
+		"Upgrade started successfully to non-recommended version with image digest in available list")
+}

--- a/pkg/jobs/utils/helpers.go
+++ b/pkg/jobs/utils/helpers.go
@@ -564,7 +564,7 @@ func GetMonitorAttempts(jobType string, curator *clustercuratorv1.ClusterCurator
 	return monitorAttempts
 }
 
-// Copied from https://github.com/stolostron/library-go which is no longed supported
+// Copied from https://github.com/stolostron/library-go which is no longer supported
 // but this is a useful func for local testing as we don't need to build the image
 // LoadConfig loads the kubeconfig and returns a *rest.Config
 // url: The url of the server

--- a/pkg/jobs/utils/helpers.go
+++ b/pkg/jobs/utils/helpers.go
@@ -176,7 +176,7 @@ func patchDyn(dynset dynamic.Interface, clusterName string, containerName string
 
 func GetDynset(dynset dynamic.Interface) (dynamic.Interface, error) {
 
-	config, err := LoadConfig("", "")
+	config, err := LoadConfig()
 	if err != nil {
 		return nil, err
 	}
@@ -186,7 +186,7 @@ func GetDynset(dynset dynamic.Interface) (dynamic.Interface, error) {
 
 func GetClient() (clientv1.Client, error) {
 
-	config, err := LoadConfig("", "")
+	config, err := LoadConfig()
 	if err != nil {
 		return nil, err
 	}
@@ -574,35 +574,20 @@ func GetMonitorAttempts(jobType string, curator *clustercuratorv1.ClusterCurator
 // If the context is not provided and the url is not provided, it returns a *rest.Config the for the current-context.
 // If the context is not provided but the url provided, it returns a *rest.Config for the server identified by the url.
 // If the context is provided, it returns a *rest.Config for the provided context.
-func LoadConfig(
-	url,
-	context string,
-) (*rest.Config, error) {
+func LoadConfig() (*rest.Config, error) {
 	kubeconfig := os.Getenv("DEV_ONLY_KUBECONFIG")
 	if kubeconfig != "" {
-		return configFromFile(url, kubeconfig, context)
+		return configFromFile(kubeconfig)
 	}
 	return rest.InClusterConfig()
 }
 
-func configFromFile(url, kubeconfig, context string) (*rest.Config, error) {
-	if context == "" {
-		// klog.V(5).Infof("clientcmd.BuildConfigFromFlags with %s and %s", url, kubeconfig)
-		// Retreive the config for the current context
-		if url == "" {
-			config, err := clientcmd.LoadFromFile(kubeconfig)
-			if err != nil {
-				return nil, err
-			}
-			return clientcmd.NewDefaultClientConfig(
-				*config,
-				&clientcmd.ConfigOverrides{}).ClientConfig()
-		}
-		return clientcmd.BuildConfigFromFlags(url, kubeconfig)
+func configFromFile(kubeconfig string) (*rest.Config, error) {
+	config, err := clientcmd.LoadFromFile(kubeconfig)
+	if err != nil {
+		return nil, err
 	}
-	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfig},
-		&clientcmd.ConfigOverrides{
-			CurrentContext: context,
-		}).ClientConfig()
+	return clientcmd.NewDefaultClientConfig(
+		*config,
+		&clientcmd.ConfigOverrides{}).ClientConfig()
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-22079

Feature to use the image digest in ClusterVersion conditionalUpdates list when the non-recommended annotation is used.

- Added code to check the conditionalUpdates list for the image digest
- If not found will check the availableUpdates list
- If still not found will fall back to use the image tag for backward compatibility
- Also reverted a change from the server foundation team and brought back the `LoadConfig()` func so we can run the curator locally otherwise it can only run in a container which makes it hard for testing. The `LoadConfig()` func was originally from https://github.com/stolostron/library-go but the repo is no longer maintained.