### PR TITLE
Add repository url label to container images

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -13,6 +13,7 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 ENV USER_UID=1001
 
 LABEL \
+      url="https://github.com/stolostron/cluster-curator-controller" \
     name="cluster-curator" \
     com.redhat.component="cluster-curator" \
     description="Cluster curator controller" \


### PR DESCRIPTION
This pull request adds the repository URL as the 'url' label to container images.

**Related Issue:** https://issues.redhat.com/browse/ACM-23275

**Epic Goal:** All ACM and MCE container images should define the url label pointing to their source repository instead of the generic 'https://www.redhat.com' value.

**Target Branch:** backplane-2.10

**Components affected:** cluster-curator-controller

**Branch details:** cluster-curator-controller (branch: backplane-2.10)

**Label added:**
- url: https://github.com/stolostron/cluster-curator-controller

This change improves traceability and helps identify the source repository for each container image, which is especially important for components like kube-rbac-proxy that exist in multiple organizations.