### PR TITLE
Use multi-arch builder for Konflux

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/stolostron/builder:go1.24-linux AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.24 AS builder
 
 WORKDIR /go/src/github.com/stolostron/cluster-curator-controller
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/stolostron/cluster-curator-controller
 
 go 1.24.0
 
-toolchain go1.24.7
-
 require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/go-logr/logr v1.4.2


### PR DESCRIPTION
The stolostron builder currently only has ARM and x86_64.

ref: https://issues.redhat.com/browse/ACM-24863