### PR TITLE
ACM-26886 Switch to use the Patch func for ClusterDeployment

### DIFF
--- a/pkg/jobs/hive/hive.go
+++ b/pkg/jobs/hive/hive.go
@@ -61,9 +61,11 @@ func ActivateDeploy(hiveset clientv1.Client, clusterName string) error {
 		}
 
 		// Update the pause annotation
+		originalCluster := cluster.DeepCopy()
 		delete(annotations, HiveReconcilePauseAnnotation)
+		patch := clientv1.MergeFrom(originalCluster)
 		cluster.SetAnnotations(annotations)
-		return hiveset.Update(context.TODO(), cluster)
+		return hiveset.Patch(context.TODO(), cluster, patch)
 	})
 	return err
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-26886

- Replace Update with Patch so any future Hive schema changes will not require updating the Hive version