### PR TITLE
feat: ACM-27433 hosted cluster nodepool only upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,28 @@ For more details on job flow within our architecture see our [**swimlane chart**
   Note: The `desiredCuration` commands are exactly the same as the Hive cluster since the controller will auto-detect the cluster type
 
   * To monitor the status of the provision you can look at either the `ClusterCurator` status or look at the job logs from the `HostedCluster` namespace.
+
+### Hosted cluster upgrade example:
+
+  For detailed documentation on upgrading hosted clusters including control plane only, NodePools only, and channel updates, see the [Hosted Cluster Upgrade Guide](docs/hosted-cluster-upgrade.md).
+
+  Quick example - upgrade both control plane and NodePools:
+  ```yaml
+  apiVersion: cluster.open-cluster-management.io/v1beta1
+  kind: ClusterCurator
+  metadata:
+    name: my-hosted-cluster
+    namespace: clusters
+  spec:
+    desiredCuration: upgrade
+    upgrade:
+      desiredUpdate: "4.14.5"
+  ```
+
+  To upgrade only the control plane, add `upgradeType: ControlPlane`. To upgrade only NodePools, add `upgradeType: NodePools`.
+
+  See [deploy/samples/clusterCurator-upgrade.yaml](deploy/samples/clusterCurator-upgrade.yaml) for more examples.
+
 ---
 
 - ### Diagnostic steps:

--- a/deploy/crd/cluster.open-cluster-management.io_clustercurators.yaml
+++ b/deploy/crd/cluster.open-cluster-management.io_clustercurators.yaml
@@ -363,6 +363,26 @@ spec:
                       upgrades. Setting both this value and DesiredUpdate triggers
                       an EUS to EUS upgrade.
                     type: string
+                  upgradeType:
+                    description: UpgradeType specifies which components to upgrade
+                      for HostedCluster deployments. For standalone clusters, this
+                      field is ignored. Supported values are ControlPlane (upgrade
+                      only the HostedCluster control plane), NodePools (upgrade only
+                      the NodePools/worker nodes), or empty string (default, upgrade
+                      both control plane and node pools).
+                    type: string
+                    enum:
+                    - ControlPlane
+                    - NodePools
+                    - ""
+                  nodePoolNames:
+                    description: NodePoolNames specifies which NodePools to upgrade
+                      when upgradeType is NodePools or empty (default). If not specified
+                      or empty, all NodePools associated with the HostedCluster will
+                      be upgraded. This field is ignored when upgradeType is ControlPlane.
+                    type: array
+                    items:
+                      type: string
                   monitorTimeout:
                     default: 120
                     description: MonitorTimeout defines the monitor process timeout,

--- a/deploy/samples/clusterCurator-upgrade.yaml
+++ b/deploy/samples/clusterCurator-upgrade.yaml
@@ -1,0 +1,86 @@
+# Sample ClusterCurator resources for upgrading hosted clusters
+# See docs/hosted-cluster-upgrade.md for detailed documentation
+
+---
+# Example 1: Upgrade both control plane and NodePools (default behavior)
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: ClusterCurator
+metadata:
+  name: my-hosted-cluster
+  namespace: clusters
+  labels:
+    open-cluster-management: curator
+spec:
+  desiredCuration: upgrade
+  upgrade:
+    desiredUpdate: "4.14.5"
+    # upgradeType is empty, so both control plane and NodePools will be upgraded
+
+---
+# Example 2: Upgrade only the control plane (HostedCluster)
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: ClusterCurator
+metadata:
+  name: my-hosted-cluster
+  namespace: clusters
+  labels:
+    open-cluster-management: curator
+spec:
+  desiredCuration: upgrade
+  upgrade:
+    desiredUpdate: "4.14.5"
+    upgradeType: ControlPlane
+
+---
+# Example 3: Upgrade only the NodePools (worker nodes)
+# NOTE: The NodePools version cannot be higher than the HostedCluster control plane version.
+#       Upgrade the control plane first if needed.
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: ClusterCurator
+metadata:
+  name: my-hosted-cluster
+  namespace: clusters
+  labels:
+    open-cluster-management: curator
+spec:
+  desiredCuration: upgrade
+  upgrade:
+    desiredUpdate: "4.14.5"
+    upgradeType: NodePools
+
+---
+# Example 4: Update channel only
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: ClusterCurator
+metadata:
+  name: my-hosted-cluster
+  namespace: clusters
+  labels:
+    open-cluster-management: curator
+spec:
+  desiredCuration: upgrade
+  upgrade:
+    channel: "fast-4.14"
+
+---
+# Example 5: Upgrade with version, channel, and Ansible hooks
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: ClusterCurator
+metadata:
+  name: my-hosted-cluster
+  namespace: clusters
+  labels:
+    open-cluster-management: curator
+spec:
+  desiredCuration: upgrade
+  upgrade:
+    desiredUpdate: "4.14.5"
+    channel: "fast-4.14"
+    monitorTimeout: 180  # Wait up to 180 minutes
+    towerAuthSecret: toweraccess
+    prehook:
+      - name: Pre-Upgrade Health Check
+        extra_vars:
+          cluster_name: my-hosted-cluster
+    posthook:
+      - name: Post-Upgrade Validation

--- a/docs/hosted-cluster-upgrade.md
+++ b/docs/hosted-cluster-upgrade.md
@@ -5,11 +5,13 @@ This document describes how to upgrade hosted clusters using the Cluster Curator
 ## Overview
 
 The Cluster Curator Controller supports upgrading hosted clusters by:
-1. Updating the cluster version (release image)
-2. Updating the cluster channel
-3. Updating both version and channel together
+1. Updating the cluster version (release image) for both control plane and NodePools
+2. Updating only the control plane (HostedCluster)
+3. Updating only the NodePools (worker nodes)
+4. Updating the cluster channel
+5. Updating both version and channel together
 
-When an upgrade is triggered, the controller patches the `HostedCluster` resource and all associated `NodePool` resources with the new configuration.
+When an upgrade is triggered, the controller patches the `HostedCluster` resource and/or associated `NodePool` resources based on the `upgradeType` configuration.
 
 ## Prerequisites
 
@@ -19,7 +21,7 @@ When an upgrade is triggered, the controller patches the `HostedCluster` resourc
 
 ## Upgrade Scenarios
 
-### 1. Version Upgrade
+### 1. Version Upgrade (Control Plane and NodePools)
 
 To upgrade to a specific OpenShift version, specify the `desiredUpdate` field:
 
@@ -40,7 +42,121 @@ This will:
 - Patch all `NodePool` resources associated with the cluster with the same image
 - Monitor the upgrade until completion
 
-### 2. Channel-Only Update
+#### Upgrading Control Plane and Specific NodePools
+
+To upgrade the control plane and only specific NodePools (not all), use the `nodePoolNames` field:
+
+```yaml
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: ClusterCurator
+metadata:
+  name: my-hosted-cluster
+  namespace: clusters
+spec:
+  desiredCuration: upgrade
+  upgrade:
+    desiredUpdate: "4.14.5"
+    nodePoolNames:
+      - my-nodepool-1
+      - my-nodepool-2
+```
+
+This will:
+- Patch the `HostedCluster` resource's `spec.release.image`
+- Patch **only** `my-nodepool-1` and `my-nodepool-2` (not other NodePools)
+- Monitor both the control plane and the specified NodePools until completion
+
+This is useful when you have multiple NodePools and want to do a rolling upgrade, upgrading the control plane along with a subset of NodePools first.
+
+### 2. Control Plane Only Upgrade
+
+To upgrade only the HostedCluster control plane without upgrading the NodePools:
+
+```yaml
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: ClusterCurator
+metadata:
+  name: my-hosted-cluster
+  namespace: clusters
+spec:
+  desiredCuration: upgrade
+  upgrade:
+    desiredUpdate: "4.14.5"
+    upgradeType: ControlPlane
+```
+
+This will:
+- Patch **only** the `HostedCluster` resource's `spec.release.image`
+- **Not** patch any `NodePool` resources
+- Monitor the `HostedCluster` status conditions until upgrade completes
+
+This is useful when you want to upgrade the control plane first and then upgrade the NodePools separately.
+
+### 3. NodePools Only Upgrade
+
+To upgrade only the NodePools without changing the HostedCluster control plane:
+
+```yaml
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: ClusterCurator
+metadata:
+  name: my-hosted-cluster
+  namespace: clusters
+spec:
+  desiredCuration: upgrade
+  upgrade:
+    desiredUpdate: "4.14.5"
+    upgradeType: NodePools
+```
+
+This will:
+- Patch **only** the `NodePool` resources' `spec.release.image`
+- **Not** patch the `HostedCluster` resource's release image
+- **Not** update the channel (even if specified)
+- Monitor the `NodePool` status until all NodePools are ready at the desired version
+
+#### Upgrading Specific NodePools
+
+By default, all NodePools associated with the HostedCluster are upgraded. To upgrade only specific NodePools, use the `nodePoolNames` field:
+
+```yaml
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: ClusterCurator
+metadata:
+  name: my-hosted-cluster
+  namespace: clusters
+spec:
+  desiredCuration: upgrade
+  upgrade:
+    desiredUpdate: "4.14.5"
+    upgradeType: NodePools
+    nodePoolNames:
+      - my-nodepool-1
+      - my-nodepool-2
+```
+
+This will:
+- Upgrade **only** the specified NodePools (`my-nodepool-1` and `my-nodepool-2`)
+- Skip any other NodePools associated with the HostedCluster
+- Monitor only the specified NodePools until they are ready at the desired version
+
+This is useful when:
+- You want to do a rolling upgrade of NodePools one at a time
+- You have multiple NodePools with different hardware profiles and want to upgrade them at different times
+- You need to test the upgrade on a subset of NodePools before upgrading the rest
+
+> **Tip:** Only include NodePools that need to be upgraded. If a NodePool is already at the target version, you don't need to include it in `nodePoolNames`. Including already-upgraded NodePools will still work (the patch is a no-op), but it's more efficient to only specify those that need upgrading.
+
+This is useful when the control plane has already been upgraded and you want to upgrade the worker nodes.
+
+> **Important:** The NodePools version cannot be higher than the HostedCluster control plane version. If you attempt to upgrade NodePools to a version higher than the control plane, you will receive an error:
+> ```
+> NodePools cannot be upgraded to version X.Y.Z which is higher than HostedCluster version A.B.C. Upgrade the control plane first
+> ```
+
+> **Note:** When `upgradeType: NodePools` is set, any `channel` value specified is ignored since channels only apply to the HostedCluster control plane.
+
+### 4. Channel-Only Update
 
 To update only the cluster channel without changing the version:
 
@@ -76,7 +192,7 @@ Common channel values:
 - `eus-4.x` - Extended Update Support channel
 - `candidate-4.x` - Candidate release channel
 
-### 3. Version and Channel Update
+### 5. Version and Channel Update
 
 To update both the version and channel simultaneously:
 
@@ -143,9 +259,98 @@ spec:
 
 ## How It Works
 
+### UpgradeType Field
+
+The `upgradeType` field controls which components are upgraded:
+
+| `upgradeType` Value | HostedCluster Upgraded | NodePools Upgraded | Channel Updated |
+|---------------------|------------------------|--------------------| ----------------|
+| `""` (empty/default) | Yes | Yes | Yes |
+| `ControlPlane` | Yes | No | Yes |
+| `NodePools` | No | Yes | No |
+
+### NodePoolNames Field
+
+The `nodePoolNames` field allows you to specify which NodePools to upgrade:
+
+| `nodePoolNames` Value | Behavior |
+|-----------------------|----------|
+| Empty or not specified | All NodePools associated with the HostedCluster are upgraded |
+| List of names | Only the specified NodePools are upgraded |
+
+This field is:
+- **Effective** when `upgradeType` is empty (default) or `NodePools`
+- **Ignored** when `upgradeType` is `ControlPlane`
+
+When `upgradeType` is empty (default) and `nodePoolNames` is specified, the control plane AND the specified NodePools are upgraded.
+
+### Re-triggering Upgrades
+
+The controller automatically detects when upgrade parameters change and triggers a new upgrade job. A new upgrade will be triggered when any of the following fields change:
+
+| Field | Description |
+|-------|-------------|
+| `desiredUpdate` | Target version changes |
+| `channel` | Cluster channel changes |
+| `upstream` | Update server changes |
+| `upgradeType` | Upgrade scope changes (e.g., from default to `NodePools`) |
+| `nodePoolNames` | List of NodePools to upgrade changes |
+
+**Example: Upgrading different NodePools sequentially**
+
+1. First, upgrade the control plane and one NodePool:
+```yaml
+spec:
+  desiredCuration: upgrade
+  upgrade:
+    desiredUpdate: "4.14.5"
+    nodePoolNames:
+      - nodepool-1
+```
+
+2. After the first upgrade completes, upgrade another NodePool by changing `nodePoolNames`:
+```yaml
+spec:
+  desiredCuration: upgrade
+  upgrade:
+    desiredUpdate: "4.14.5"
+    nodePoolNames:
+      - nodepool-2
+```
+
+The controller detects that `nodePoolNames` changed and automatically triggers a new upgrade job for `nodepool-2`.
+
+> **Best Practice:** Only specify NodePools that need to be upgraded. If you include a NodePool that is already at the target version (e.g., `nodePoolNames: [nodepool-1, nodepool-2]` when `nodepool-1` is already upgraded), the controller will:
+> - Patch both NodePools (no-op for `nodepool-1` since it's already at the target version)
+> - Monitor both NodePools (immediate success for `nodepool-1` since it's already ready)
+>
+> While this works correctly, it's more efficient to only specify NodePools that actually need upgrading.
+
+**Example: Changing upgrade scope**
+
+1. First, upgrade only the control plane:
+```yaml
+spec:
+  desiredCuration: upgrade
+  upgrade:
+    desiredUpdate: "4.14.5"
+    upgradeType: ControlPlane
+```
+
+2. After the control plane upgrade completes, upgrade the NodePools:
+```yaml
+spec:
+  desiredCuration: upgrade
+  upgrade:
+    desiredUpdate: "4.14.5"
+    upgradeType: NodePools
+```
+
+The controller detects that `upgradeType` changed and triggers a new upgrade job for the NodePools.
+
 ### HostedCluster Resource Changes
 
-When upgrading, the controller patches these fields on the `HostedCluster`:
+When upgrading (with `upgradeType` empty or `ControlPlane`), the controller patches these fields on the `HostedCluster`:
 
 **For version upgrade:**
 ```yaml
@@ -162,7 +367,7 @@ spec:
 
 ### NodePool Resource Changes
 
-For version upgrades, all `NodePool` resources belonging to the cluster are patched:
+For version upgrades (with `upgradeType` empty or `NodePools`), all `NodePool` resources belonging to the cluster are patched:
 
 ```yaml
 spec:
@@ -174,16 +379,31 @@ spec:
 
 ### Monitoring
 
-The controller monitors the upgrade by checking the `HostedCluster` status conditions:
+The controller monitors the upgrade differently based on the `upgradeType`:
 
-**For version upgrades, all these conditions must be met:**
-- `Degraded: False`
-- `Available: True`
-- `ClusterVersionProgressing: False`
-- `ClusterVersionAvailable: True`
-- `Progressing: False`
-- `ClusterVersionProgressing.message` contains "Cluster version is"
-- `ClusterVersionAvailable.message` contains "Done applying"
+**For default upgrades (both control plane and NodePools):**
+- Monitors `HostedCluster` status conditions until ready
+- Additionally verifies all `NodePool` resources have:
+  - `status.version` matching the desired version
+  - `Ready` condition is `True`
+  - `UpdatingVersion` condition is `False`
+
+**For control plane only upgrades (`upgradeType: ControlPlane`):**
+- Monitors only the `HostedCluster` status conditions:
+  - `Degraded: False`
+  - `Available: True`
+  - `ClusterVersionProgressing: False`
+  - `ClusterVersionAvailable: True`
+  - `Progressing: False`
+  - `ClusterVersionProgressing.message` contains "Cluster version is"
+  - `ClusterVersionAvailable.message` contains "Done applying"
+
+**For NodePools only upgrades (`upgradeType: NodePools`):**
+- Monitors only the `NodePool` resources until all have:
+  - `status.version` matching the desired version
+  - `spec.release.image` matching the expected image
+  - `Ready` condition is `True`
+  - `UpdatingVersion` condition is `False`
 
 **For channel-only updates:**
 - The controller verifies that `spec.channel` matches the desired channel
@@ -253,6 +473,10 @@ oc logs job/<curator-job-name> -n clusters -c monitor-upgrade
 4. **"Timed out waiting for job"**
    - The upgrade did not complete within the `monitorTimeout` period
    - Check the `HostedCluster` status conditions for errors
+
+5. **"NodePools cannot be upgraded to version X.Y.Z which is higher than HostedCluster version A.B.C"**
+   - When using `upgradeType: NodePools`, the target version cannot exceed the HostedCluster control plane version
+   - Upgrade the control plane first using `upgradeType: ControlPlane`, then upgrade the NodePools
 
 ### Verify HostedCluster State
 

--- a/pkg/api/v1beta1/clustercurator_types.go
+++ b/pkg/api/v1beta1/clustercurator_types.go
@@ -130,6 +130,22 @@ type UpgradeHooks struct {
 	// +optional
 	Upstream string `json:"upstream,omitempty"`
 
+	// UpgradeType specifies which components to upgrade for HostedCluster deployments.
+	// For standalone clusters, this field is ignored.
+	// Supported values are:
+	// - "ControlPlane" - upgrade only the HostedCluster control plane
+	// - "NodePools" - upgrade only the NodePools (worker nodes)
+	// - "" (empty, default) - upgrade both control plane and node pools
+	// +optional
+	// +kubebuilder:validation:Enum=ControlPlane;NodePools;""
+	UpgradeType UpgradeType `json:"upgradeType,omitempty"`
+
+	// NodePoolNames specifies which NodePools to upgrade when upgradeType is "NodePools" or empty (default).
+	// If not specified or empty, all NodePools associated with the HostedCluster will be upgraded.
+	// This field is ignored when upgradeType is "ControlPlane".
+	// +optional
+	NodePoolNames []string `json:"nodePoolNames,omitempty"`
+
 	// Jobs to run before the cluster upgrade.
 	Prehook []Hook `json:"prehook,omitempty"`
 
@@ -165,6 +181,18 @@ const (
 
 	// HookTypeWorkflow, the hook is an Ansible Workflow template
 	HookTypeWorkflow HookType = "Workflow"
+)
+
+// UpgradeType indicates which components to upgrade for HostedCluster deployments.
+// +kubebuilder:validation:Enum=ControlPlane;NodePools;""
+type UpgradeType string
+
+const (
+	// UpgradeTypeControlPlane upgrades only the HostedCluster control plane
+	UpgradeTypeControlPlane UpgradeType = "ControlPlane"
+
+	// UpgradeTypeNodePools upgrades only the NodePools (worker nodes)
+	UpgradeTypeNodePools UpgradeType = "NodePools"
 )
 
 // +kubebuilder:object:root=true

--- a/pkg/jobs/hypershift/hypershift_test.go
+++ b/pkg/jobs/hypershift/hypershift_test.go
@@ -96,6 +96,93 @@ func getHostedClusterWithChannel(hcType string, channel string, hcConditions []i
 	}
 }
 
+func getHostedClusterWithVersion(hcType string, version string, hcConditions []interface{}) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "hypershift.openshift.io/v1beta1",
+			"kind":       "HostedCluster",
+			"metadata": map[string]interface{}{
+				"name":      ClusterName,
+				"namespace": ClusterNamespace,
+				"labels": map[string]interface{}{
+					"hypershift.openshift.io/auto-created-for-infra": ClusterName + "-xyz",
+				},
+			},
+			"spec": map[string]interface{}{
+				"pausedUntil": "true",
+				"platform": map[string]interface{}{
+					"type": hcType,
+				},
+				"release": map[string]interface{}{
+					"image": "quay.io/openshift-release-dev/ocp-release:" + version + "-multi",
+				},
+			},
+			"status": map[string]interface{}{
+				"conditions": hcConditions,
+				"version": map[string]interface{}{
+					"history": []interface{}{
+						map[string]interface{}{
+							"version": version,
+							"state":   "Completed",
+						},
+					},
+					"desired": map[string]interface{}{
+						"version": version,
+					},
+				},
+			},
+		},
+	}
+}
+
+func getHostedClusterWithChannelAndVersion(hcType string, channel string, version string, hcConditions []interface{}) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "hypershift.openshift.io/v1beta1",
+			"kind":       "HostedCluster",
+			"metadata": map[string]interface{}{
+				"name":      ClusterName,
+				"namespace": ClusterNamespace,
+				"labels": map[string]interface{}{
+					"hypershift.openshift.io/auto-created-for-infra": ClusterName + "-xyz",
+				},
+			},
+			"spec": map[string]interface{}{
+				"pausedUntil": "true",
+				"channel":     channel,
+				"platform": map[string]interface{}{
+					"type": hcType,
+				},
+				"release": map[string]interface{}{
+					"image": "quay.io/openshift-release-dev/ocp-release:" + version + "-multi",
+				},
+			},
+			"status": map[string]interface{}{
+				"conditions": hcConditions,
+				"version": map[string]interface{}{
+					"history": []interface{}{
+						map[string]interface{}{
+							"version": version,
+							"state":   "Completed",
+						},
+					},
+					"desired": map[string]interface{}{
+						"channels": []interface{}{
+							"candidate-4.13",
+							"candidate-4.14",
+							"fast-4.13",
+							"fast-4.14",
+							"stable-4.13",
+							"stable-4.14",
+						},
+						"version": version,
+					},
+				},
+			},
+		},
+	}
+}
+
 func getHostedClusterNoLabel(hcType string, hcConditions []interface{}) *unstructured.Unstructured {
 	return &unstructured.Unstructured{
 		Object: map[string]interface{}{
@@ -135,6 +222,39 @@ func getNodepool(npName string, npNamespace string, npClusterName string) *unstr
 				"clusterName": npClusterName,
 				"release": map[string]interface{}{
 					"image": "quay.io/openshift-release-dev/ocp-release:4.13.6-multi",
+				},
+			},
+		},
+	}
+}
+
+func getNodepoolWithVersion(npName string, npNamespace string, npClusterName string, version string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "hypershift.openshift.io/v1beta1",
+			"kind":       "NodePool",
+			"metadata": map[string]interface{}{
+				"name":      npName,
+				"namespace": npNamespace,
+			},
+			"spec": map[string]interface{}{
+				"pausedUntil": "true",
+				"clusterName": npClusterName,
+				"release": map[string]interface{}{
+					"image": "quay.io/openshift-release-dev/ocp-release:" + version + "-multi",
+				},
+			},
+			"status": map[string]interface{}{
+				"version": version,
+				"conditions": []interface{}{
+					map[string]interface{}{
+						"type":   "Ready",
+						"status": "True",
+					},
+					map[string]interface{}{
+						"type":   "UpdatingVersion",
+						"status": "False",
+					},
 				},
 			},
 		},
@@ -202,6 +322,26 @@ func getUpgradeWithChannelClusterCurator(desiredUpdate string, channel string) *
 			Upgrade: clustercuratorv1.UpgradeHooks{
 				DesiredUpdate:  desiredUpdate,
 				Channel:        channel,
+				MonitorTimeout: 5,
+			},
+			Destroy: clustercuratorv1.Hooks{
+				JobMonitorTimeout: 1,
+			},
+		},
+	}
+}
+
+func getUpgradeClusterCuratorWithType(desiredUpdate string, upgradeType clustercuratorv1.UpgradeType) *clustercuratorv1.ClusterCurator {
+	return &clustercuratorv1.ClusterCurator{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      ClusterName,
+			Namespace: ClusterNamespace,
+		},
+		Spec: clustercuratorv1.ClusterCuratorSpec{
+			DesiredCuration: "upgrade",
+			Upgrade: clustercuratorv1.UpgradeHooks{
+				DesiredUpdate:  desiredUpdate,
+				UpgradeType:    upgradeType,
 				MonitorTimeout: 5,
 			},
 			Destroy: clustercuratorv1.Hooks{
@@ -621,7 +761,7 @@ func TestMonitorUpgradeStatusCompleted(t *testing.T) {
 				"message": "HostedCluster is at expected version",
 			},
 		}),
-		getNodepool(NodepoolName, ClusterNamespace, ClusterName),
+		getNodepoolWithVersion(NodepoolName, ClusterNamespace, ClusterName, "4.13.7"),
 	)
 	s.AddKnownTypes(clustercuratorv1.SchemeBuilder.GroupVersion, &clustercuratorv1.ClusterCurator{})
 	s.AddKnownTypes(managedclusterinfov1beta1.SchemeGroupVersion, &managedclusterinfov1beta1.ManagedClusterInfo{})
@@ -666,7 +806,7 @@ func TestMonitorUpgradeStatusWaitForUpdate(t *testing.T) {
 				"message": "HostedCluster is at expected version",
 			},
 		}),
-		getNodepool(NodepoolName, ClusterNamespace, ClusterName),
+		getNodepoolWithVersion(NodepoolName, ClusterNamespace, ClusterName, "4.13.7"),
 	)
 	s.AddKnownTypes(clustercuratorv1.SchemeBuilder.GroupVersion, &clustercuratorv1.ClusterCurator{})
 	s.AddKnownTypes(managedclusterinfov1beta1.SchemeGroupVersion, &managedclusterinfov1beta1.ManagedClusterInfo{})
@@ -1046,4 +1186,1004 @@ func TestUpgradeClusterInvalidChannel(t *testing.T) {
 	assert.NotNil(t, err, "err should not be nil when invalid channel is provided")
 	assert.Contains(t, err.Error(), "is not valid")
 	assert.Contains(t, err.Error(), "Available channels")
+}
+
+// Tests for UpgradeType: ControlPlane only
+func TestUpgradeClusterControlPlaneOnly(t *testing.T) {
+	clusterCurator := getUpgradeClusterCuratorWithType("4.13.7", clustercuratorv1.UpgradeTypeControlPlane)
+	managedClusterInfo := getManagedClusterInfo()
+	dynfake := dynfake.NewSimpleDynamicClient(
+		runtime.NewScheme(),
+		getHostedCluster("AWS", []interface{}{
+			map[string]interface{}{
+				"type":    "Degraded",
+				"status":  "False",
+				"message": "The hosted cluster is not degraded",
+			},
+			map[string]interface{}{
+				"type":    "ClusterVersionAvailable",
+				"status":  "True",
+				"message": "Done applying 4.13.6",
+			},
+			map[string]interface{}{
+				"type":    "Available",
+				"status":  "False",
+				"message": "The hosted control plane is available",
+			},
+			map[string]interface{}{
+				"type":    "ClusterVersionProgressing",
+				"status":  "False",
+				"message": "Cluster version is 4.13.6",
+			},
+			map[string]interface{}{
+				"type":    "Progressing",
+				"status":  "False",
+				"message": "HostedCluster is at expected version",
+			},
+		}),
+		getNodepool(NodepoolName, ClusterNamespace, ClusterName),
+	)
+	s.AddKnownTypes(clustercuratorv1.SchemeBuilder.GroupVersion, &clustercuratorv1.ClusterCurator{})
+	s.AddKnownTypes(managedclusterinfov1beta1.SchemeGroupVersion, &managedclusterinfov1beta1.ManagedClusterInfo{})
+	client := clientfake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(clusterCurator, managedClusterInfo).Build()
+
+	assert.Nil(
+		t,
+		UpgradeCluster(client, dynfake, ClusterName, clusterCurator),
+		"err is nil, when ControlPlane only upgrade is performed",
+	)
+
+	// Verify the HostedCluster was upgraded
+	hc, err := dynfake.Resource(utils.HCGVR).Namespace(ClusterNamespace).Get(context.TODO(), ClusterName, v1.GetOptions{})
+	assert.Nil(t, err, "should be able to get HostedCluster")
+	spec := hc.Object["spec"].(map[string]interface{})
+	release := spec["release"].(map[string]interface{})
+	assert.Equal(t, "quay.io/openshift-release-dev/ocp-release:4.13.7-multi", release["image"], "HostedCluster image should be updated")
+
+	// Verify the NodePool was NOT upgraded
+	np, err := dynfake.Resource(utils.NPGVR).Namespace(ClusterNamespace).Get(context.TODO(), NodepoolName, v1.GetOptions{})
+	assert.Nil(t, err, "should be able to get NodePool")
+	npSpec := np.Object["spec"].(map[string]interface{})
+	npRelease := npSpec["release"].(map[string]interface{})
+	assert.Equal(t, "quay.io/openshift-release-dev/ocp-release:4.13.6-multi", npRelease["image"], "NodePool image should NOT be updated")
+}
+
+// Tests for UpgradeType: NodePools only
+func TestUpgradeClusterNodePoolsOnly(t *testing.T) {
+	// HostedCluster is at 4.14.0, upgrading NodePools from 4.13.6 to 4.13.7 (below HC version)
+	clusterCurator := getUpgradeClusterCuratorWithType("4.13.7", clustercuratorv1.UpgradeTypeNodePools)
+	managedClusterInfo := getManagedClusterInfo() // NodePools at 4.13.6
+	dynfake := dynfake.NewSimpleDynamicClient(
+		runtime.NewScheme(),
+		getHostedClusterWithVersion("AWS", "4.14.0", []interface{}{
+			map[string]interface{}{
+				"type":    "Degraded",
+				"status":  "False",
+				"message": "The hosted cluster is not degraded",
+			},
+			map[string]interface{}{
+				"type":    "ClusterVersionAvailable",
+				"status":  "True",
+				"message": "Done applying 4.14.0",
+			},
+			map[string]interface{}{
+				"type":    "Available",
+				"status":  "False",
+				"message": "The hosted control plane is available",
+			},
+			map[string]interface{}{
+				"type":    "ClusterVersionProgressing",
+				"status":  "False",
+				"message": "Cluster version is 4.14.0",
+			},
+			map[string]interface{}{
+				"type":    "Progressing",
+				"status":  "False",
+				"message": "HostedCluster is at expected version",
+			},
+		}),
+		getNodepool(NodepoolName, ClusterNamespace, ClusterName),
+	)
+	s.AddKnownTypes(clustercuratorv1.SchemeBuilder.GroupVersion, &clustercuratorv1.ClusterCurator{})
+	s.AddKnownTypes(managedclusterinfov1beta1.SchemeGroupVersion, &managedclusterinfov1beta1.ManagedClusterInfo{})
+	client := clientfake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(clusterCurator, managedClusterInfo).Build()
+
+	assert.Nil(
+		t,
+		UpgradeCluster(client, dynfake, ClusterName, clusterCurator),
+		"err is nil, when NodePools only upgrade is performed",
+	)
+
+	// Verify the HostedCluster was NOT upgraded (still at 4.14.0)
+	hc, err := dynfake.Resource(utils.HCGVR).Namespace(ClusterNamespace).Get(context.TODO(), ClusterName, v1.GetOptions{})
+	assert.Nil(t, err, "should be able to get HostedCluster")
+	spec := hc.Object["spec"].(map[string]interface{})
+	release := spec["release"].(map[string]interface{})
+	assert.Equal(t, "quay.io/openshift-release-dev/ocp-release:4.14.0-multi", release["image"], "HostedCluster image should NOT be updated")
+
+	// Verify the NodePool was upgraded
+	np, err := dynfake.Resource(utils.NPGVR).Namespace(ClusterNamespace).Get(context.TODO(), NodepoolName, v1.GetOptions{})
+	assert.Nil(t, err, "should be able to get NodePool")
+	npSpec := np.Object["spec"].(map[string]interface{})
+	npRelease := npSpec["release"].(map[string]interface{})
+	assert.Equal(t, "quay.io/openshift-release-dev/ocp-release:4.13.7-multi", npRelease["image"], "NodePool image should be updated")
+}
+
+// Test MonitorUpgradeStatus for ControlPlane only
+func TestMonitorUpgradeStatusControlPlaneOnly(t *testing.T) {
+	clusterCurator := getUpgradeClusterCuratorWithType("4.13.7", clustercuratorv1.UpgradeTypeControlPlane)
+	dynfake := dynfake.NewSimpleDynamicClient(
+		runtime.NewScheme(),
+		getHostedCluster("AWS", []interface{}{
+			map[string]interface{}{
+				"type":    "Degraded",
+				"status":  "False",
+				"message": "The hosted cluster is not degraded",
+			},
+			map[string]interface{}{
+				"type":    "ClusterVersionAvailable",
+				"status":  "True",
+				"message": "Done applying 4.13.7",
+			},
+			map[string]interface{}{
+				"type":    "Available",
+				"status":  "True",
+				"message": "The hosted control plane is available",
+			},
+			map[string]interface{}{
+				"type":    "ClusterVersionProgressing",
+				"status":  "False",
+				"message": "Cluster version is 4.13.7",
+			},
+			map[string]interface{}{
+				"type":    "Progressing",
+				"status":  "False",
+				"message": "HostedCluster is at expected version",
+			},
+		}),
+		// NodePool is still at old version - should not matter for ControlPlane only
+		getNodepool(NodepoolName, ClusterNamespace, ClusterName),
+	)
+	s.AddKnownTypes(clustercuratorv1.SchemeBuilder.GroupVersion, &clustercuratorv1.ClusterCurator{})
+	client := clientfake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(clusterCurator).Build()
+
+	assert.Nil(
+		t,
+		MonitorUpgradeStatus(dynfake, client, ClusterName, clusterCurator),
+		"err is nil, when ControlPlane only upgrade monitoring succeeds",
+	)
+}
+
+// Test MonitorUpgradeStatus for NodePools only
+func TestMonitorUpgradeStatusNodePoolsOnly(t *testing.T) {
+	clusterCurator := getUpgradeClusterCuratorWithType("4.13.7", clustercuratorv1.UpgradeTypeNodePools)
+	dynfake := dynfake.NewSimpleDynamicClient(
+		runtime.NewScheme(),
+		getHostedCluster("AWS", []interface{}{
+			map[string]interface{}{
+				"type":    "Degraded",
+				"status":  "False",
+				"message": "The hosted cluster is not degraded",
+			},
+			map[string]interface{}{
+				"type":    "ClusterVersionAvailable",
+				"status":  "True",
+				"message": "Done applying 4.13.6", // Still at old version
+			},
+			map[string]interface{}{
+				"type":    "Available",
+				"status":  "True",
+				"message": "The hosted control plane is available",
+			},
+			map[string]interface{}{
+				"type":    "ClusterVersionProgressing",
+				"status":  "False",
+				"message": "Cluster version is 4.13.6", // Still at old version
+			},
+			map[string]interface{}{
+				"type":    "Progressing",
+				"status":  "False",
+				"message": "HostedCluster is at expected version",
+			},
+		}),
+		// NodePool is at new version with Ready status
+		getNodepoolWithVersion(NodepoolName, ClusterNamespace, ClusterName, "4.13.7"),
+	)
+	s.AddKnownTypes(clustercuratorv1.SchemeBuilder.GroupVersion, &clustercuratorv1.ClusterCurator{})
+	client := clientfake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(clusterCurator).Build()
+
+	assert.Nil(
+		t,
+		MonitorUpgradeStatus(dynfake, client, ClusterName, clusterCurator),
+		"err is nil, when NodePools only upgrade monitoring succeeds",
+	)
+}
+
+// Test that NodePools cannot be upgraded to a version higher than HostedCluster
+func TestUpgradeClusterNodePoolsVersionHigherThanHostedCluster(t *testing.T) {
+	// NodePools at 4.13.6, trying to upgrade to 4.14.0 which is higher than HostedCluster version
+	clusterCurator := getUpgradeClusterCuratorWithType("4.14.0", clustercuratorv1.UpgradeTypeNodePools)
+	managedClusterInfo := getManagedClusterInfo() // Returns 4.13.6
+	dynfake := dynfake.NewSimpleDynamicClient(
+		runtime.NewScheme(),
+		getHostedClusterWithVersion("AWS", "4.13.6", []interface{}{
+			map[string]interface{}{
+				"type":    "Degraded",
+				"status":  "False",
+				"message": "The hosted cluster is not degraded",
+			},
+		}),
+		getNodepool(NodepoolName, ClusterNamespace, ClusterName),
+	)
+	s.AddKnownTypes(clustercuratorv1.SchemeBuilder.GroupVersion, &clustercuratorv1.ClusterCurator{})
+	s.AddKnownTypes(managedclusterinfov1beta1.SchemeGroupVersion, &managedclusterinfov1beta1.ManagedClusterInfo{})
+	client := clientfake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(clusterCurator, managedClusterInfo).Build()
+
+	err := UpgradeCluster(client, dynfake, ClusterName, clusterCurator)
+	assert.NotNil(t, err, "err should not be nil when NodePools version is higher than HostedCluster")
+	assert.Contains(t, err.Error(), "NodePools cannot be upgraded to version")
+	assert.Contains(t, err.Error(), "higher than HostedCluster version")
+}
+
+// Test that NodePools can be upgraded to the same version as HostedCluster
+func TestUpgradeClusterNodePoolsSameVersionAsHostedCluster(t *testing.T) {
+	// HostedCluster at 4.14.0, upgrading NodePools to 4.14.0 (same version)
+	clusterCurator := getUpgradeClusterCuratorWithType("4.14.0", clustercuratorv1.UpgradeTypeNodePools)
+	managedClusterInfo := &managedclusterinfov1beta1.ManagedClusterInfo{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      ClusterName,
+			Namespace: ClusterName,
+		},
+		Status: managedclusterinfov1beta1.ClusterInfoStatus{
+			DistributionInfo: managedclusterinfov1beta1.DistributionInfo{
+				OCP: managedclusterinfov1beta1.OCPDistributionInfo{
+					Version: "4.13.6", // NodePools current version
+				},
+			},
+		},
+	}
+	dynfake := dynfake.NewSimpleDynamicClient(
+		runtime.NewScheme(),
+		getHostedClusterWithVersion("AWS", "4.14.0", []interface{}{
+			map[string]interface{}{
+				"type":    "Degraded",
+				"status":  "False",
+				"message": "The hosted cluster is not degraded",
+			},
+		}),
+		getNodepool(NodepoolName, ClusterNamespace, ClusterName),
+	)
+	s.AddKnownTypes(clustercuratorv1.SchemeBuilder.GroupVersion, &clustercuratorv1.ClusterCurator{})
+	s.AddKnownTypes(managedclusterinfov1beta1.SchemeGroupVersion, &managedclusterinfov1beta1.ManagedClusterInfo{})
+	client := clientfake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(clusterCurator, managedClusterInfo).Build()
+
+	err := UpgradeCluster(client, dynfake, ClusterName, clusterCurator)
+	assert.Nil(t, err, "err should be nil when NodePools version equals HostedCluster version")
+}
+
+// Test that NodePools upgrade does not fail when ManagedClusterInfo reports control plane version
+// This tests the scenario where:
+// - Control plane (HostedCluster) is at 4.14.0
+// - ManagedClusterInfo reports 4.14.0 (control plane version)
+// - NodePools are at 4.13.6
+// - Desired upgrade is 4.14.0 (to bring NodePools to control plane version)
+// Before the fix, this would fail with "Cannot upgrade to the same version" because
+// ManagedClusterInfo.Version (4.14.0) == desiredUpdate (4.14.0)
+func TestUpgradeClusterNodePoolsWhenManagedClusterInfoReportsControlPlaneVersion(t *testing.T) {
+	clusterCurator := getUpgradeClusterCuratorWithType("4.14.0", clustercuratorv1.UpgradeTypeNodePools)
+	// ManagedClusterInfo reports control plane version (4.14.0), not NodePool version
+	managedClusterInfo := &managedclusterinfov1beta1.ManagedClusterInfo{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      ClusterName,
+			Namespace: ClusterName,
+		},
+		Status: managedclusterinfov1beta1.ClusterInfoStatus{
+			DistributionInfo: managedclusterinfov1beta1.DistributionInfo{
+				OCP: managedclusterinfov1beta1.OCPDistributionInfo{
+					Version: "4.14.0", // Control plane version (same as desired!)
+				},
+			},
+		},
+	}
+	dynfake := dynfake.NewSimpleDynamicClient(
+		runtime.NewScheme(),
+		getHostedClusterWithVersion("AWS", "4.14.0", []interface{}{
+			map[string]interface{}{
+				"type":    "Degraded",
+				"status":  "False",
+				"message": "The hosted cluster is not degraded",
+			},
+		}),
+		getNodepool(NodepoolName, ClusterNamespace, ClusterName), // NodePool at 4.13.6
+	)
+	s.AddKnownTypes(clustercuratorv1.SchemeBuilder.GroupVersion, &clustercuratorv1.ClusterCurator{})
+	s.AddKnownTypes(managedclusterinfov1beta1.SchemeGroupVersion, &managedclusterinfov1beta1.ManagedClusterInfo{})
+	client := clientfake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(clusterCurator, managedClusterInfo).Build()
+
+	// This should succeed - NodePools-only upgrade skips the "same version" check against ManagedClusterInfo
+	err := UpgradeCluster(client, dynfake, ClusterName, clusterCurator)
+	assert.Nil(t, err, "NodePools upgrade should not fail when ManagedClusterInfo reports control plane version")
+}
+
+// Test that NodePools can be upgraded to a lower version than HostedCluster
+func TestUpgradeClusterNodePoolsLowerVersionThanHostedCluster(t *testing.T) {
+	// HostedCluster at 4.14.0, upgrading NodePools to 4.13.7 (lower version, catching up)
+	clusterCurator := getUpgradeClusterCuratorWithType("4.13.7", clustercuratorv1.UpgradeTypeNodePools)
+	managedClusterInfo := getManagedClusterInfo() // Returns 4.13.6
+	dynfake := dynfake.NewSimpleDynamicClient(
+		runtime.NewScheme(),
+		getHostedClusterWithVersion("AWS", "4.14.0", []interface{}{
+			map[string]interface{}{
+				"type":    "Degraded",
+				"status":  "False",
+				"message": "The hosted cluster is not degraded",
+			},
+		}),
+		getNodepool(NodepoolName, ClusterNamespace, ClusterName),
+	)
+	s.AddKnownTypes(clustercuratorv1.SchemeBuilder.GroupVersion, &clustercuratorv1.ClusterCurator{})
+	s.AddKnownTypes(managedclusterinfov1beta1.SchemeGroupVersion, &managedclusterinfov1beta1.ManagedClusterInfo{})
+	client := clientfake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(clusterCurator, managedClusterInfo).Build()
+
+	err := UpgradeCluster(client, dynfake, ClusterName, clusterCurator)
+	assert.Nil(t, err, "err should be nil when NodePools version is lower than HostedCluster version")
+}
+
+// Test that channel is not updated when upgradeType is NodePools
+func TestUpgradeClusterNodePoolsOnlyIgnoresChannel(t *testing.T) {
+	// HostedCluster is at 4.14.0, upgrading NodePools from 4.13.6 to 4.13.7 with channel (should be ignored)
+	clusterCurator := &clustercuratorv1.ClusterCurator{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      ClusterName,
+			Namespace: ClusterNamespace,
+		},
+		Spec: clustercuratorv1.ClusterCuratorSpec{
+			DesiredCuration: "upgrade",
+			Upgrade: clustercuratorv1.UpgradeHooks{
+				DesiredUpdate:  "4.13.7",
+				Channel:        "fast-4.14", // This should be ignored
+				UpgradeType:    clustercuratorv1.UpgradeTypeNodePools,
+				MonitorTimeout: 5,
+			},
+			Destroy: clustercuratorv1.Hooks{
+				JobMonitorTimeout: 1,
+			},
+		},
+	}
+	managedClusterInfo := getManagedClusterInfo() // NodePools at 4.13.6
+	dynfake := dynfake.NewSimpleDynamicClient(
+		runtime.NewScheme(),
+		getHostedClusterWithChannelAndVersion("AWS", "stable-4.13", "4.14.0", []interface{}{
+			map[string]interface{}{
+				"type":    "Degraded",
+				"status":  "False",
+				"message": "The hosted cluster is not degraded",
+			},
+			map[string]interface{}{
+				"type":    "ClusterVersionAvailable",
+				"status":  "True",
+				"message": "Done applying 4.14.0",
+			},
+			map[string]interface{}{
+				"type":    "Available",
+				"status":  "False",
+				"message": "The hosted control plane is available",
+			},
+			map[string]interface{}{
+				"type":    "ClusterVersionProgressing",
+				"status":  "False",
+				"message": "Cluster version is 4.14.0",
+			},
+			map[string]interface{}{
+				"type":    "Progressing",
+				"status":  "False",
+				"message": "HostedCluster is at expected version",
+			},
+		}),
+		getNodepool(NodepoolName, ClusterNamespace, ClusterName),
+	)
+	s.AddKnownTypes(clustercuratorv1.SchemeBuilder.GroupVersion, &clustercuratorv1.ClusterCurator{})
+	s.AddKnownTypes(managedclusterinfov1beta1.SchemeGroupVersion, &managedclusterinfov1beta1.ManagedClusterInfo{})
+	client := clientfake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(clusterCurator, managedClusterInfo).Build()
+
+	assert.Nil(
+		t,
+		UpgradeCluster(client, dynfake, ClusterName, clusterCurator),
+		"err is nil, when NodePools only upgrade is performed with channel specified",
+	)
+
+	// Verify the channel was NOT updated on HostedCluster
+	hc, err := dynfake.Resource(utils.HCGVR).Namespace(ClusterNamespace).Get(context.TODO(), ClusterName, v1.GetOptions{})
+	assert.Nil(t, err, "should be able to get HostedCluster")
+	spec := hc.Object["spec"].(map[string]interface{})
+	assert.Equal(t, "stable-4.13", spec["channel"], "channel should NOT be updated for NodePools only upgrade")
+}
+
+// ============================================================================
+// Additional tests for improved code coverage
+// ============================================================================
+
+// Test areNodePoolsReady when NodePool has no status
+func TestAreNodePoolsReadyNoStatus(t *testing.T) {
+	np := getNodepool(NodepoolName, ClusterNamespace, ClusterName)
+	// Remove status from nodepool
+	delete(np.Object, "status")
+
+	dynfake := dynfake.NewSimpleDynamicClient(runtime.NewScheme(), np)
+
+	ready, err := areNodePoolsReady(dynfake, ClusterName, ClusterNamespace, "4.13.7", nil)
+	assert.Nil(t, err, "should not return error")
+	assert.False(t, ready, "should return false when NodePool has no status")
+}
+
+// Test areNodePoolsReady when NodePool is still updating version
+func TestAreNodePoolsReadyUpdatingVersion(t *testing.T) {
+	np := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "hypershift.openshift.io/v1beta1",
+			"kind":       "NodePool",
+			"metadata": map[string]interface{}{
+				"name":      NodepoolName,
+				"namespace": ClusterNamespace,
+			},
+			"spec": map[string]interface{}{
+				"clusterName": ClusterName,
+				"release": map[string]interface{}{
+					"image": "quay.io/openshift-release-dev/ocp-release:4.13.7-multi",
+				},
+			},
+			"status": map[string]interface{}{
+				"version": "4.13.7",
+				"conditions": []interface{}{
+					map[string]interface{}{
+						"type":   "Ready",
+						"status": "True",
+					},
+					map[string]interface{}{
+						"type":   "UpdatingVersion",
+						"status": "True", // Still updating
+					},
+				},
+			},
+		},
+	}
+
+	dynfake := dynfake.NewSimpleDynamicClient(runtime.NewScheme(), np)
+
+	ready, err := areNodePoolsReady(dynfake, ClusterName, ClusterNamespace, "4.13.7", nil)
+	assert.Nil(t, err, "should not return error")
+	assert.False(t, ready, "should return false when NodePool is still updating version")
+}
+
+// Test areNodePoolsReady when NodePool Ready condition is False
+func TestAreNodePoolsReadyNotReady(t *testing.T) {
+	np := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "hypershift.openshift.io/v1beta1",
+			"kind":       "NodePool",
+			"metadata": map[string]interface{}{
+				"name":      NodepoolName,
+				"namespace": ClusterNamespace,
+			},
+			"spec": map[string]interface{}{
+				"clusterName": ClusterName,
+				"release": map[string]interface{}{
+					"image": "quay.io/openshift-release-dev/ocp-release:4.13.7-multi",
+				},
+			},
+			"status": map[string]interface{}{
+				"version": "4.13.7",
+				"conditions": []interface{}{
+					map[string]interface{}{
+						"type":   "Ready",
+						"status": "False", // Not ready
+					},
+					map[string]interface{}{
+						"type":   "UpdatingVersion",
+						"status": "False",
+					},
+				},
+			},
+		},
+	}
+
+	dynfake := dynfake.NewSimpleDynamicClient(runtime.NewScheme(), np)
+
+	ready, err := areNodePoolsReady(dynfake, ClusterName, ClusterNamespace, "4.13.7", nil)
+	assert.Nil(t, err, "should not return error")
+	assert.False(t, ready, "should return false when NodePool is not ready")
+}
+
+// Test areNodePoolsReady when NodePool spec image doesn't match
+func TestAreNodePoolsReadyImageMismatch(t *testing.T) {
+	np := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "hypershift.openshift.io/v1beta1",
+			"kind":       "NodePool",
+			"metadata": map[string]interface{}{
+				"name":      NodepoolName,
+				"namespace": ClusterNamespace,
+			},
+			"spec": map[string]interface{}{
+				"clusterName": ClusterName,
+				"release": map[string]interface{}{
+					"image": "quay.io/openshift-release-dev/ocp-release:4.13.6-multi", // Old version
+				},
+			},
+			"status": map[string]interface{}{
+				"version": "4.13.7",
+				"conditions": []interface{}{
+					map[string]interface{}{
+						"type":   "Ready",
+						"status": "True",
+					},
+					map[string]interface{}{
+						"type":   "UpdatingVersion",
+						"status": "False",
+					},
+				},
+			},
+		},
+	}
+
+	dynfake := dynfake.NewSimpleDynamicClient(runtime.NewScheme(), np)
+
+	ready, err := areNodePoolsReady(dynfake, ClusterName, ClusterNamespace, "4.13.7", nil)
+	assert.Nil(t, err, "should not return error")
+	assert.False(t, ready, "should return false when NodePool spec image doesn't match")
+}
+
+// Test areNodePoolsReady when NodePool status.version is nil
+func TestAreNodePoolsReadyNoStatusVersion(t *testing.T) {
+	np := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "hypershift.openshift.io/v1beta1",
+			"kind":       "NodePool",
+			"metadata": map[string]interface{}{
+				"name":      NodepoolName,
+				"namespace": ClusterNamespace,
+			},
+			"spec": map[string]interface{}{
+				"clusterName": ClusterName,
+				"release": map[string]interface{}{
+					"image": "quay.io/openshift-release-dev/ocp-release:4.13.7-multi",
+				},
+			},
+			"status": map[string]interface{}{
+				// No version field
+				"conditions": []interface{}{
+					map[string]interface{}{
+						"type":   "Ready",
+						"status": "True",
+					},
+					map[string]interface{}{
+						"type":   "UpdatingVersion",
+						"status": "False",
+					},
+				},
+			},
+		},
+	}
+
+	dynfake := dynfake.NewSimpleDynamicClient(runtime.NewScheme(), np)
+
+	ready, err := areNodePoolsReady(dynfake, ClusterName, ClusterNamespace, "4.13.7", nil)
+	assert.Nil(t, err, "should not return error")
+	assert.False(t, ready, "should return false when NodePool status.version is nil")
+}
+
+// Test areNodePoolsReady when NodePool status.version doesn't match
+func TestAreNodePoolsReadyVersionMismatch(t *testing.T) {
+	np := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "hypershift.openshift.io/v1beta1",
+			"kind":       "NodePool",
+			"metadata": map[string]interface{}{
+				"name":      NodepoolName,
+				"namespace": ClusterNamespace,
+			},
+			"spec": map[string]interface{}{
+				"clusterName": ClusterName,
+				"release": map[string]interface{}{
+					"image": "quay.io/openshift-release-dev/ocp-release:4.13.7-multi",
+				},
+			},
+			"status": map[string]interface{}{
+				"version": "4.13.6", // Doesn't match desired 4.13.7
+				"conditions": []interface{}{
+					map[string]interface{}{
+						"type":   "Ready",
+						"status": "True",
+					},
+					map[string]interface{}{
+						"type":   "UpdatingVersion",
+						"status": "False",
+					},
+				},
+			},
+		},
+	}
+
+	dynfake := dynfake.NewSimpleDynamicClient(runtime.NewScheme(), np)
+
+	ready, err := areNodePoolsReady(dynfake, ClusterName, ClusterNamespace, "4.13.7", nil)
+	assert.Nil(t, err, "should not return error")
+	assert.False(t, ready, "should return false when NodePool status.version doesn't match")
+}
+
+// Test getHostedClusterVersion with no status
+func TestGetHostedClusterVersionNoStatus(t *testing.T) {
+	hc := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "hypershift.openshift.io/v1beta1",
+			"kind":       "HostedCluster",
+			"metadata": map[string]interface{}{
+				"name":      ClusterName,
+				"namespace": ClusterNamespace,
+			},
+			"spec": map[string]interface{}{},
+			// No status
+		},
+	}
+
+	dynfake := dynfake.NewSimpleDynamicClient(runtime.NewScheme(), hc)
+
+	version, err := getHostedClusterVersion(dynfake, ClusterName, ClusterNamespace)
+	assert.NotNil(t, err, "should return error when no status")
+	assert.Contains(t, err.Error(), "Unable to determine HostedCluster version")
+	assert.Empty(t, version, "version should be empty")
+}
+
+// Test getHostedClusterVersion with status but no version
+func TestGetHostedClusterVersionNoVersionInStatus(t *testing.T) {
+	hc := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "hypershift.openshift.io/v1beta1",
+			"kind":       "HostedCluster",
+			"metadata": map[string]interface{}{
+				"name":      ClusterName,
+				"namespace": ClusterNamespace,
+			},
+			"spec": map[string]interface{}{},
+			"status": map[string]interface{}{
+				"conditions": []interface{}{},
+				// No version field
+			},
+		},
+	}
+
+	dynfake := dynfake.NewSimpleDynamicClient(runtime.NewScheme(), hc)
+
+	version, err := getHostedClusterVersion(dynfake, ClusterName, ClusterNamespace)
+	assert.NotNil(t, err, "should return error when no version in status")
+	assert.Contains(t, err.Error(), "Unable to determine HostedCluster version")
+	assert.Empty(t, version, "version should be empty")
+}
+
+// Test getHostedClusterVersion with empty history but has desired.version (fallback)
+func TestGetHostedClusterVersionFallbackToDesired(t *testing.T) {
+	hc := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "hypershift.openshift.io/v1beta1",
+			"kind":       "HostedCluster",
+			"metadata": map[string]interface{}{
+				"name":      ClusterName,
+				"namespace": ClusterNamespace,
+			},
+			"spec": map[string]interface{}{},
+			"status": map[string]interface{}{
+				"version": map[string]interface{}{
+					"history": []interface{}{}, // Empty history
+					"desired": map[string]interface{}{
+						"version": "4.14.0", // Fallback to desired
+					},
+				},
+			},
+		},
+	}
+
+	dynfake := dynfake.NewSimpleDynamicClient(runtime.NewScheme(), hc)
+
+	version, err := getHostedClusterVersion(dynfake, ClusterName, ClusterNamespace)
+	assert.Nil(t, err, "should not return error")
+	assert.Equal(t, "4.14.0", version, "should return desired.version as fallback")
+}
+
+// Test getHostedClusterVersion with history
+func TestGetHostedClusterVersionFromHistory(t *testing.T) {
+	hc := getHostedClusterWithVersion("AWS", "4.14.0", []interface{}{})
+
+	dynfake := dynfake.NewSimpleDynamicClient(runtime.NewScheme(), hc)
+
+	version, err := getHostedClusterVersion(dynfake, ClusterName, ClusterNamespace)
+	assert.Nil(t, err, "should not return error")
+	assert.Equal(t, "4.14.0", version, "should return version from history")
+}
+
+// Test MonitorUpgradeStatus for NodePools only with timeout
+func TestMonitorUpgradeStatusNodePoolsOnlyTimeout(t *testing.T) {
+	// NodePool is not ready - should timeout
+	clusterCurator := &clustercuratorv1.ClusterCurator{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      ClusterName,
+			Namespace: ClusterNamespace,
+		},
+		Spec: clustercuratorv1.ClusterCuratorSpec{
+			DesiredCuration: "upgrade",
+			Upgrade: clustercuratorv1.UpgradeHooks{
+				DesiredUpdate:  "4.13.7",
+				UpgradeType:    clustercuratorv1.UpgradeTypeNodePools,
+				MonitorTimeout: 1, // Very short timeout (1 minute = 1 attempt)
+			},
+		},
+	}
+	// NodePool at old version, not ready
+	np := getNodepool(NodepoolName, ClusterNamespace, ClusterName) // 4.13.6
+	hc := getHostedClusterWithVersion("AWS", "4.14.0", []interface{}{})
+
+	dynfake := dynfake.NewSimpleDynamicClient(runtime.NewScheme(), hc, np)
+	s.AddKnownTypes(clustercuratorv1.SchemeBuilder.GroupVersion, &clustercuratorv1.ClusterCurator{})
+	client := clientfake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(clusterCurator).Build()
+
+	err := MonitorUpgradeStatus(dynfake, client, ClusterName, clusterCurator)
+	assert.NotNil(t, err, "should return error on timeout")
+	assert.Contains(t, err.Error(), "Timed out waiting for NodePools upgrade")
+}
+
+// Test MonitorUpgradeStatus for default upgrade type (both HC and NPs)
+func TestMonitorUpgradeStatusDefaultBothReady(t *testing.T) {
+	clusterCurator := getUpgradeClusterCurator("4.13.7")
+	dynfake := dynfake.NewSimpleDynamicClient(
+		runtime.NewScheme(),
+		getHostedCluster("AWS", []interface{}{
+			map[string]interface{}{
+				"type":    "Degraded",
+				"status":  "False",
+				"message": "The hosted cluster is not degraded",
+			},
+			map[string]interface{}{
+				"type":    "ClusterVersionAvailable",
+				"status":  "True",
+				"message": "Done applying 4.13.7",
+			},
+			map[string]interface{}{
+				"type":    "Available",
+				"status":  "True",
+				"message": "The hosted control plane is available",
+			},
+			map[string]interface{}{
+				"type":    "ClusterVersionProgressing",
+				"status":  "False",
+				"message": "Cluster version is 4.13.7",
+			},
+			map[string]interface{}{
+				"type":    "Progressing",
+				"status":  "False",
+				"message": "HostedCluster is at expected version",
+			},
+		}),
+		getNodepoolWithVersion(NodepoolName, ClusterNamespace, ClusterName, "4.13.7"),
+	)
+	s.AddKnownTypes(clustercuratorv1.SchemeBuilder.GroupVersion, &clustercuratorv1.ClusterCurator{})
+	client := clientfake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(clusterCurator).Build()
+
+	err := MonitorUpgradeStatus(dynfake, client, ClusterName, clusterCurator)
+	assert.Nil(t, err, "should succeed when both HC and NPs are ready")
+}
+
+// Test MonitorUpgradeStatus for default upgrade type when HC ready but NPs not ready initially
+func TestMonitorUpgradeStatusDefaultNodePoolsNotReadyInitially(t *testing.T) {
+	clusterCurator := getUpgradeClusterCurator("4.13.7")
+	// Start with NodePool not at the right version
+	npNotReady := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "hypershift.openshift.io/v1beta1",
+			"kind":       "NodePool",
+			"metadata": map[string]interface{}{
+				"name":      NodepoolName,
+				"namespace": ClusterNamespace,
+			},
+			"spec": map[string]interface{}{
+				"clusterName": ClusterName,
+				"release": map[string]interface{}{
+					"image": "quay.io/openshift-release-dev/ocp-release:4.13.7-multi",
+				},
+			},
+			"status": map[string]interface{}{
+				"version": "4.13.6", // Old version
+				"conditions": []interface{}{
+					map[string]interface{}{
+						"type":   "Ready",
+						"status": "True",
+					},
+					map[string]interface{}{
+						"type":   "UpdatingVersion",
+						"status": "True", // Still updating
+					},
+				},
+			},
+		},
+	}
+	dynfake := dynfake.NewSimpleDynamicClient(
+		runtime.NewScheme(),
+		getHostedCluster("AWS", []interface{}{
+			map[string]interface{}{
+				"type":    "Degraded",
+				"status":  "False",
+				"message": "The hosted cluster is not degraded",
+			},
+			map[string]interface{}{
+				"type":    "ClusterVersionAvailable",
+				"status":  "True",
+				"message": "Done applying 4.13.7",
+			},
+			map[string]interface{}{
+				"type":    "Available",
+				"status":  "True",
+				"message": "The hosted control plane is available",
+			},
+			map[string]interface{}{
+				"type":    "ClusterVersionProgressing",
+				"status":  "False",
+				"message": "Cluster version is 4.13.7",
+			},
+			map[string]interface{}{
+				"type":    "Progressing",
+				"status":  "False",
+				"message": "HostedCluster is at expected version",
+			},
+		}),
+		npNotReady,
+	)
+	s.AddKnownTypes(clustercuratorv1.SchemeBuilder.GroupVersion, &clustercuratorv1.ClusterCurator{})
+	client := clientfake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(clusterCurator).Build()
+
+	// Update NodePool to ready state after a short time
+	go func() {
+		time.Sleep(utils.PauseTenSeconds)
+		npReady := getNodepoolWithVersion(NodepoolName, ClusterNamespace, ClusterName, "4.13.7")
+		_, err := dynfake.Resource(utils.NPGVR).Namespace(ClusterNamespace).Update(context.TODO(), npReady, v1.UpdateOptions{})
+		assert.Nil(t, err, "should update NodePool")
+	}()
+
+	err := MonitorUpgradeStatus(dynfake, client, ClusterName, clusterCurator)
+	assert.Nil(t, err, "should succeed after NodePool becomes ready")
+}
+
+// Test areNodePoolsReady with multiple NodePools (one for cluster, one not)
+func TestAreNodePoolsReadyMultipleNodePools(t *testing.T) {
+	// NodePool belonging to our cluster - ready
+	np1 := getNodepoolWithVersion(NodepoolName, ClusterNamespace, ClusterName, "4.13.7")
+	// NodePool belonging to another cluster - should be ignored
+	np2 := getNodepoolWithVersion("other-cluster-np", ClusterNamespace, "other-cluster", "4.12.0")
+
+	dynfake := dynfake.NewSimpleDynamicClient(runtime.NewScheme(), np1, np2)
+
+	ready, err := areNodePoolsReady(dynfake, ClusterName, ClusterNamespace, "4.13.7", nil)
+	assert.Nil(t, err, "should not return error")
+	assert.True(t, ready, "should return true - only check NodePools for our cluster")
+}
+
+// Test areNodePoolsReady with specific NodePool names filter
+func TestAreNodePoolsReadyWithSpecificNames(t *testing.T) {
+	// NodePool1 ready at desired version
+	np1 := getNodepoolWithVersion("nodepool-1", ClusterNamespace, ClusterName, "4.13.7")
+	// NodePool2 NOT ready (old version) - but should be ignored since we only specify nodepool-1
+	np2 := getNodepoolWithVersion("nodepool-2", ClusterNamespace, ClusterName, "4.13.6")
+
+	dynfake := dynfake.NewSimpleDynamicClient(runtime.NewScheme(), np1, np2)
+
+	// Only check nodepool-1
+	ready, err := areNodePoolsReady(dynfake, ClusterName, ClusterNamespace, "4.13.7", []string{"nodepool-1"})
+	assert.Nil(t, err, "should not return error")
+	assert.True(t, ready, "should return true - only nodepool-1 is checked and it's ready")
+}
+
+// Test areNodePoolsReady when specified NodePool is not ready
+func TestAreNodePoolsReadyWithSpecificNamesNotReady(t *testing.T) {
+	// NodePool1 ready at desired version
+	np1 := getNodepoolWithVersion("nodepool-1", ClusterNamespace, ClusterName, "4.13.7")
+	// NodePool2 NOT ready (old version)
+	np2 := getNodepoolWithVersion("nodepool-2", ClusterNamespace, ClusterName, "4.13.6")
+
+	dynfake := dynfake.NewSimpleDynamicClient(runtime.NewScheme(), np1, np2)
+
+	// Check nodepool-2 which is not ready
+	ready, err := areNodePoolsReady(dynfake, ClusterName, ClusterNamespace, "4.13.7", []string{"nodepool-2"})
+	assert.Nil(t, err, "should not return error")
+	assert.False(t, ready, "should return false - nodepool-2 is not at desired version")
+}
+
+// Test upgrading specific NodePools only
+func TestUpgradeClusterSpecificNodePools(t *testing.T) {
+	clusterCurator := &clustercuratorv1.ClusterCurator{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      ClusterName,
+			Namespace: ClusterNamespace,
+		},
+		Spec: clustercuratorv1.ClusterCuratorSpec{
+			DesiredCuration: "upgrade",
+			Upgrade: clustercuratorv1.UpgradeHooks{
+				DesiredUpdate: "4.13.7",
+				UpgradeType:   clustercuratorv1.UpgradeTypeNodePools,
+				NodePoolNames: []string{"nodepool-1"}, // Only upgrade nodepool-1
+			},
+		},
+	}
+	managedClusterInfo := &managedclusterinfov1beta1.ManagedClusterInfo{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      ClusterName,
+			Namespace: ClusterName,
+		},
+		Status: managedclusterinfov1beta1.ClusterInfoStatus{
+			DistributionInfo: managedclusterinfov1beta1.DistributionInfo{
+				OCP: managedclusterinfov1beta1.OCPDistributionInfo{
+					Version: "4.13.7", // Control plane version
+				},
+			},
+		},
+	}
+	hc := getHostedClusterWithVersion("AWS", "4.13.7", []interface{}{
+		map[string]interface{}{
+			"type":    "Degraded",
+			"status":  "False",
+			"message": "The hosted cluster is not degraded",
+		},
+	})
+	np1 := getNodepool("nodepool-1", ClusterNamespace, ClusterName)
+	np2 := getNodepool("nodepool-2", ClusterNamespace, ClusterName)
+
+	dynfake := dynfake.NewSimpleDynamicClient(runtime.NewScheme(), hc, np1, np2)
+	s.AddKnownTypes(clustercuratorv1.SchemeBuilder.GroupVersion, &clustercuratorv1.ClusterCurator{})
+	s.AddKnownTypes(managedclusterinfov1beta1.SchemeGroupVersion, &managedclusterinfov1beta1.ManagedClusterInfo{})
+	client := clientfake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(clusterCurator, managedClusterInfo).Build()
+
+	err := UpgradeCluster(client, dynfake, ClusterName, clusterCurator)
+	assert.Nil(t, err, "err should be nil when upgrading specific NodePools")
+
+	// Verify nodepool-1 was upgraded
+	updatedNp1, _ := dynfake.Resource(utils.NPGVR).Namespace(ClusterNamespace).Get(context.TODO(), "nodepool-1", v1.GetOptions{})
+	np1Spec := updatedNp1.Object["spec"].(map[string]interface{})
+	np1Release := np1Spec["release"].(map[string]interface{})
+	assert.Equal(t, "quay.io/openshift-release-dev/ocp-release:4.13.7-multi", np1Release["image"], "nodepool-1 should be upgraded")
+
+	// Verify nodepool-2 was NOT upgraded
+	updatedNp2, _ := dynfake.Resource(utils.NPGVR).Namespace(ClusterNamespace).Get(context.TODO(), "nodepool-2", v1.GetOptions{})
+	np2Spec := updatedNp2.Object["spec"].(map[string]interface{})
+	np2Release := np2Spec["release"].(map[string]interface{})
+	assert.Equal(t, "quay.io/openshift-release-dev/ocp-release:4.13.6-multi", np2Release["image"], "nodepool-2 should NOT be upgraded")
+}
+
+// Test getHostedClusterVersion when history exists but version field in history is nil
+func TestGetHostedClusterVersionHistoryNoVersion(t *testing.T) {
+	hc := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "hypershift.openshift.io/v1beta1",
+			"kind":       "HostedCluster",
+			"metadata": map[string]interface{}{
+				"name":      ClusterName,
+				"namespace": ClusterNamespace,
+			},
+			"spec": map[string]interface{}{},
+			"status": map[string]interface{}{
+				"version": map[string]interface{}{
+					"history": []interface{}{
+						map[string]interface{}{
+							"state": "Completed",
+							// No version field
+						},
+					},
+					"desired": map[string]interface{}{
+						"version": "4.14.0", // Fallback
+					},
+				},
+			},
+		},
+	}
+
+	dynfake := dynfake.NewSimpleDynamicClient(runtime.NewScheme(), hc)
+
+	version, err := getHostedClusterVersion(dynfake, ClusterName, ClusterNamespace)
+	assert.Nil(t, err, "should not return error - fallback to desired")
+	assert.Equal(t, "4.14.0", version, "should return desired.version as fallback")
 }

--- a/pkg/jobs/utils/helpers_test.go
+++ b/pkg/jobs/utils/helpers_test.go
@@ -643,6 +643,119 @@ func TestNeedToUpgrade(t *testing.T) {
 			expectedUpgrade: true,
 			expectedErr:     false,
 		},
+		{
+			name: "upgradeType is changed",
+			curator: clustercuratorv1.ClusterCurator{
+				Spec: clustercuratorv1.ClusterCuratorSpec{
+					Upgrade: clustercuratorv1.UpgradeHooks{
+						DesiredUpdate: "4.14.0",
+						UpgradeType:   clustercuratorv1.UpgradeTypeNodePools,
+					},
+				},
+				Status: clustercuratorv1.ClusterCuratorStatus{
+					Conditions: []v1.Condition{
+						{
+							Message: "curator-job-xxxx DesiredCuration: upgrade Version (4.14.0;;;;)",
+							Status:  v1.ConditionTrue,
+							Type:    "clustercurator-job",
+						},
+					},
+				},
+			},
+			expectedUpgrade: true,
+			expectedErr:     false,
+		},
+		{
+			name: "nodePoolNames is changed",
+			curator: clustercuratorv1.ClusterCurator{
+				Spec: clustercuratorv1.ClusterCuratorSpec{
+					Upgrade: clustercuratorv1.UpgradeHooks{
+						DesiredUpdate: "4.14.0",
+						UpgradeType:   clustercuratorv1.UpgradeTypeNodePools,
+						NodePoolNames: []string{"nodepool-2"},
+					},
+				},
+				Status: clustercuratorv1.ClusterCuratorStatus{
+					Conditions: []v1.Condition{
+						{
+							Message: "curator-job-xxxx DesiredCuration: upgrade Version (4.14.0;;;NodePools;nodepool-1)",
+							Status:  v1.ConditionTrue,
+							Type:    "clustercurator-job",
+						},
+					},
+				},
+			},
+			expectedUpgrade: true,
+			expectedErr:     false,
+		},
+		{
+			name: "upgradeType and nodePoolNames unchanged",
+			curator: clustercuratorv1.ClusterCurator{
+				Spec: clustercuratorv1.ClusterCuratorSpec{
+					Upgrade: clustercuratorv1.UpgradeHooks{
+						DesiredUpdate: "4.14.0",
+						UpgradeType:   clustercuratorv1.UpgradeTypeNodePools,
+						NodePoolNames: []string{"nodepool-1"},
+					},
+				},
+				Status: clustercuratorv1.ClusterCuratorStatus{
+					Conditions: []v1.Condition{
+						{
+							Message: "curator-job-xxxx DesiredCuration: upgrade Version (4.14.0;;;NodePools;nodepool-1)",
+							Status:  v1.ConditionTrue,
+							Type:    "clustercurator-job",
+						},
+					},
+				},
+			},
+			expectedUpgrade: false,
+			expectedErr:     false,
+		},
+		{
+			name: "failed job - upgradeType changed",
+			curator: clustercuratorv1.ClusterCurator{
+				Spec: clustercuratorv1.ClusterCuratorSpec{
+					Upgrade: clustercuratorv1.UpgradeHooks{
+						DesiredUpdate: "4.14.0",
+						UpgradeType:   clustercuratorv1.UpgradeTypeNodePools,
+					},
+				},
+				Status: clustercuratorv1.ClusterCuratorStatus{
+					Conditions: []v1.Condition{
+						{
+							Message: "curator-job-xxxx DesiredCuration: upgrade Version (4.14.0;;;;) Failed - error",
+							Status:  v1.ConditionTrue,
+							Type:    "clustercurator-job",
+						},
+					},
+				},
+			},
+			expectedUpgrade: true,
+			expectedErr:     false,
+		},
+		{
+			name: "failed job - nodePoolNames changed",
+			curator: clustercuratorv1.ClusterCurator{
+				Spec: clustercuratorv1.ClusterCuratorSpec{
+					Upgrade: clustercuratorv1.UpgradeHooks{
+						DesiredUpdate: "4.14.0",
+						UpgradeType:   clustercuratorv1.UpgradeTypeNodePools,
+						NodePoolNames: []string{"nodepool-2"},
+					},
+				},
+				Status: clustercuratorv1.ClusterCuratorStatus{
+					Conditions: []v1.Condition{
+						{
+							Message: "curator-job-xxxx DesiredCuration: upgrade Version (4.14.0;;;NodePools;nodepool-1) Failed - error",
+							Status:  v1.ConditionTrue,
+							Type:    "clustercurator-job",
+						},
+					},
+				},
+			},
+			expectedUpgrade: true,
+			expectedErr:     false,
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
## Summary

Implements ACM-27433: Add support for individual HostedCluster control plane or NodePool upgrades.

Previously, ClusterCurator only supported upgrading both the HostedCluster control plane and NodePools together. This change enables users to upgrade them individually, which is required for the Console team to deliver a complete HC upgrade experience in ACM 2.16.

## Changes

### API Changes
- Added `UpgradeType` field to `UpgradeHooks` struct with values:
  - `ControlPlane` - upgrade only the HostedCluster control plane
  - `NodePools` - upgrade only the NodePools (worker nodes)
  - Empty (default) - upgrade both (existing behavior)

### Upgrade Logic (`pkg/jobs/hypershift/hypershift.go`)
- Modified `UpgradeCluster()` to selectively upgrade components based on `upgradeType`
- Modified `MonitorUpgradeStatus()` to monitor appropriate components based on `upgradeType`
- Added `getHostedClusterVersion()` helper to retrieve HostedCluster version from status
- Added validation: NodePools cannot be upgraded to a version higher than the HostedCluster control plane version
- Channel updates are skipped when `upgradeType: NodePools` (channels only apply to control plane)

### Monitoring Enhancements
- For NodePools-only upgrades, monitors `status.version` on NodePool resources to confirm upgrade completion
- Added `monitorNodePoolsUpgrade()` and `areNodePoolsReady()` helper functions

### Tests (`pkg/jobs/hypershift/hypershift_test.go`)
- Added tests for control plane only upgrade
- Added tests for NodePools only upgrade
- Added tests for NodePools version validation (cannot exceed HostedCluster version)
- Added test verifying channel is ignored for NodePools-only upgrades

### Documentation
- Updated `docs/hosted-cluster-upgrade.md` with new upgrade scenarios and examples
- Added `deploy/samples/clusterCurator-upgrade.yaml` with sample configurations
- Updated `README.md` with reference to upgrade documentation