### PR TITLE
Update created AnsibleJob to use top-level inventory field

### DIFF
--- a/pkg/jobs/ansible/job.go
+++ b/pkg/jobs/ansible/job.go
@@ -388,7 +388,7 @@ func RunAnsibleJob(
 	}
 
 	if curator.Spec.Inventory != "" {
-		ansibleJob.Object["spec"].(map[string]interface{})["extra_vars"].(map[string]interface{})["inventory"] = curator.Spec.Inventory
+		ansibleJob.Object["spec"].(map[string]interface{})["inventory"] = curator.Spec.Inventory
 	}
 
 	klog.V(0).Info("Creating AnsibleJob " + ansibleJob.GetName() + " in namespace " + namespace)

--- a/pkg/jobs/ansible/job_test.go
+++ b/pkg/jobs/ansible/job_test.go
@@ -807,13 +807,13 @@ func TestInventory(t *testing.T) {
 			aJob, err := RunAnsibleJob(client, cc, POSTHOOK, cc.Spec.Install.Posthook[0], "toweraccess")
 			assert.Nil(t, err, "err is nil when job is started")
 
-			extraVars := aJob.Object["spec"].(map[string]interface{})["extra_vars"].(map[string]interface{})
-			assert.NotNil(t, extraVars, "not nil, extra_vars")
+			spec := aJob.Object["spec"].(map[string]interface{})
+			assert.NotNil(t, spec, "not nil, spec")
 
-			_, existed := extraVars["inventory"]
+			_, existed := spec["inventory"]
 			assert.Equal(t, existed, test.expectedInventory)
 			if test.expectedInventory {
-				assert.Equal(t, extraVars["inventory"], test.expectedInventoryVar)
+				assert.Equal(t, spec["inventory"], test.expectedInventoryVar)
 			}
 		})
 	}


### PR DESCRIPTION
The `inventory` property on the upstream AnsibleJob needs to be set at `AnsibleJob.spec.inventory`, not `AnsibleJob.spec.extra_vars.inventory`.

This can be seen at <https://github.com/ansible/awx-resource-operator/blob/devel/roles/job_runner/tasks/launch_job.yml#L8> and is documented at <https://github.com/ansible/awx-resource-operator#ansiblejob>.

Fixes #587.