### PR TITLE
ACM-39045: Bump Go to 1.26 to address CVE-2026-27145

### DIFF
--- a/Dockerfile.prow
+++ b/Dockerfile.prow
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux as builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux as builder
 
 WORKDIR /go/src/github.com/stolostron/cluster-curator-controller
 COPY . .

--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
 
 WORKDIR /go/src/github.com/stolostron/cluster-curator-controller
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/cluster-curator-controller
 
-go 1.25.0
+go 1.26
 
 require (
 	github.com/blang/semver/v4 v4.0.0


### PR DESCRIPTION
## Summary

Bump Go builder images from 1.25 to 1.26 to address CVE-2026-27145 (crypto/x509 DoS).
Apply the #593 to the branch `backplane-2.10`

## Changes

- `go.mod`: `go 1.25` → `go 1.26`
- `Dockerfile.prow`: stolostron builder `go1.25-linux` → `go1.26-linux`
- `Dockerfile.rhtap`: brew builder `rhel_9_1.25` → `rhel_9_1.26`