### PR TITLE
Close upgrade cleanup gap for cluster-wide curator-crb

### DIFF
--- a/controllers/clustercurator_controller.go
+++ b/controllers/clustercurator_controller.go
@@ -62,6 +62,21 @@ func (r *ClusterCuratorReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 	isPosthookOnly := curator.Operation != nil && curator.Operation.RetryPosthook != ""
 
+	// Independent of desiredCuration/curatingJob state below: for Hypershift curators,
+	// make sure the shared cluster-wide curator-crb ClusterRoleBinding isn't left
+	// granting this namespace's cluster-installer SA cluster-wide managedclusters
+	// access once no job is actively running. This specifically covers upgrade
+	// curations, where desiredCuration intentionally never clears back to "" (see
+	// utils.NeedToUpgrade), so the CuratingJob/DesiredCuration-gated cleanup block
+	// below never triggers CleanupRBACHypershift for that path. Safe to call even
+	// when a new curation job is about to launch immediately after - see
+	// CleanupCuratorCRBIfOwned's doc comment.
+	if curator.Name != curator.Namespace && curator.Spec.CuratingJob == "" {
+		if err := rbac.CleanupCuratorCRBIfOwned(r.Kubeset, curator.Namespace); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
 	// Curating work has already started OR no curation work supplied curator.Spec.CuratingJob != "" ||
 	if (curator.Spec.CuratingJob != "" || curator.Spec.DesiredCuration == "") && !isPosthookOnly {
 		log.V(3).Info("No curation to do for %v", req.NamespacedName)
@@ -157,12 +172,15 @@ func newClusterCuratorPredicate() predicate.Predicate {
 				if newClusterCurator.Operation != nil && newClusterCurator.Operation.RetryPosthook != "" {
 					return true
 				}
-			if newClusterCurator.Spec.DesiredCuration != oldClusterCurator.Spec.DesiredCuration && newClusterCurator.Spec.DesiredCuration == "" {
-				// Allow through so the reconcile can perform post-curation RBAC cleanup.
-				return true
-			}
+				if newClusterCurator.Spec.DesiredCuration != oldClusterCurator.Spec.DesiredCuration && newClusterCurator.Spec.DesiredCuration == "" {
+					// Allow through so the reconcile can perform post-curation RBAC cleanup.
+					return true
+				}
 				if newClusterCurator.Spec.CuratingJob != oldClusterCurator.Spec.CuratingJob && newClusterCurator.Spec.CuratingJob == "" {
-					return false
+					// Allow through so Reconcile can clean up curator-crb for the
+					// upgrade path, where DesiredCuration doesn't change (unlike
+					// install/destroy, which are already allowed through above).
+					return true
 				}
 				if oldClusterCurator.Spec.Upgrade.IntermediateUpdate != "" {
 					return false

--- a/controllers/clustercurator_controller_test.go
+++ b/controllers/clustercurator_controller_test.go
@@ -1,0 +1,180 @@
+// Copyright Contributors to the Open Cluster Management project.
+
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/fake"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	clustercuratorv1 "github.com/stolostron/cluster-curator-controller/pkg/api/v1beta1"
+	"github.com/stolostron/cluster-curator-controller/pkg/jobs/rbac"
+)
+
+const testClusterName = "hosted-cluster-1"
+const testCuratorNamespace = "clusters"
+
+func getHypershiftUpgradeDoneCurator() *clustercuratorv1.ClusterCurator {
+	return &clustercuratorv1.ClusterCurator{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testClusterName,
+			Namespace: testCuratorNamespace,
+		},
+		Spec: clustercuratorv1.ClusterCuratorSpec{
+			// DesiredCuration intentionally stays "upgrade" after completion (see
+			// utils.NeedToUpgrade); CuratingJob is cleared once the job finishes.
+			DesiredCuration: "upgrade",
+			CuratingJob:     "",
+			Upgrade: clustercuratorv1.UpgradeHooks{
+				DesiredUpdate: "4.11.4",
+			},
+		},
+		Status: clustercuratorv1.ClusterCuratorStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:               "clustercurator-job",
+					Status:             metav1.ConditionTrue,
+					Reason:             "JobHasFinished",
+					Message:            "curator-job-abc DesiredCuration: upgrade Version (4.11.4;;;;)",
+					LastTransitionTime: metav1.Now(),
+				},
+			},
+		},
+	}
+}
+
+func newTestReconciler(t *testing.T, objs ...client.Object) (*ClusterCuratorReconciler, *fake.Clientset) {
+	s := runtime.NewScheme()
+	assert.Nil(t, clustercuratorv1.AddToScheme(s))
+
+	builder := clientfake.NewClientBuilder().WithScheme(s)
+	for _, o := range objs {
+		builder = builder.WithObjects(o)
+	}
+
+	kubeset := fake.NewSimpleClientset()
+
+	return &ClusterCuratorReconciler{
+		Client:  builder.Build(),
+		Kubeset: kubeset,
+		Log:     logr.Discard(),
+	}, kubeset
+}
+
+// TestReconcileCleansUpCuratorCRBAfterHypershiftUpgrade covers the de-scoped fix
+// for the upgrade-cleanup gap: since DesiredCuration never clears to "" for
+// upgrade, the CleanupRBAC/CleanupRBACHypershift block never fires, but the
+// cluster-wide curator-crb ClusterRoleBinding must still be reclaimed so it
+// doesn't keep granting cluster-wide managedclusters access once the upgrade
+// job is no longer running.
+func TestReconcileCleansUpCuratorCRBAfterHypershiftUpgrade(t *testing.T) {
+	curator := getHypershiftUpgradeDoneCurator()
+	r, kubeset := newTestReconciler(t, curator)
+
+	// Simulate the RBAC left over from the upgrade curation that just finished.
+	assert.Nil(t, rbac.ApplyRBAC(kubeset, testCuratorNamespace))
+	assert.Nil(t, rbac.ApplyRBACHypershift(kubeset, testClusterName, testCuratorNamespace))
+
+	crb, err := kubeset.RbacV1().ClusterRoleBindings().Get(context.TODO(), "curator-crb", metav1.GetOptions{})
+	assert.Nil(t, err, "curator-crb should exist before reconcile")
+	assert.Equal(t, testCuratorNamespace, crb.Subjects[0].Namespace)
+
+	_, err = r.Reconcile(context.TODO(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: testClusterName, Namespace: testCuratorNamespace},
+	})
+	assert.Nil(t, err, "err nil on reconcile")
+
+	t.Log("curator-crb should be deleted since it still belonged to this namespace")
+	_, err = kubeset.RbacV1().ClusterRoleBindings().Get(context.TODO(), "curator-crb", metav1.GetOptions{})
+	assert.NotNil(t, err, "curator-crb should be gone after reconcile")
+
+	t.Log("Accepted residue: SA and namespaced RoleBindings remain (not cleaned up for upgrade)")
+	_, err = kubeset.CoreV1().ServiceAccounts(testCuratorNamespace).Get(context.TODO(), "cluster-installer", metav1.GetOptions{})
+	assert.Nil(t, err, "SA should still exist (accepted residue for upgrade)")
+	_, err = kubeset.RbacV1().RoleBindings(testCuratorNamespace).Get(context.TODO(), "curator", metav1.GetOptions{})
+	assert.Nil(t, err, "curatorNamespace RoleBinding should still exist (accepted residue for upgrade)")
+	_, err = kubeset.RbacV1().RoleBindings(testClusterName).Get(context.TODO(), "curator", metav1.GetOptions{})
+	assert.Nil(t, err, "cluster-namespace RoleBinding should still exist (accepted residue for upgrade)")
+}
+
+// TestReconcileCuratorCRBCleanupPreservesOtherNamespace ensures that reconciling
+// a Hypershift curator whose upgrade just completed does not revoke a different,
+// still-active Hypershift curation's claim on the shared curator-crb.
+func TestReconcileCuratorCRBCleanupPreservesOtherNamespace(t *testing.T) {
+	curator := getHypershiftUpgradeDoneCurator()
+	r, kubeset := newTestReconciler(t, curator)
+
+	assert.Nil(t, rbac.ApplyRBAC(kubeset, testCuratorNamespace))
+	assert.Nil(t, rbac.ApplyRBACHypershift(kubeset, testClusterName, testCuratorNamespace))
+
+	// A different Hypershift curation, in a different namespace, takes over
+	// curator-crb before this one's upgrade-completion reconcile runs.
+	otherNamespace := "other-clusters"
+	assert.Nil(t, rbac.ApplyRBACHypershift(kubeset, "another-cluster", otherNamespace))
+
+	_, err := r.Reconcile(context.TODO(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: testClusterName, Namespace: testCuratorNamespace},
+	})
+	assert.Nil(t, err, "err nil on reconcile")
+
+	crb, err := kubeset.RbacV1().ClusterRoleBindings().Get(context.TODO(), "curator-crb", metav1.GetOptions{})
+	assert.Nil(t, err, "curator-crb must be preserved since it now belongs to otherNamespace")
+	assert.Equal(t, otherNamespace, crb.Subjects[0].Namespace,
+		"curator-crb subject namespace must remain otherNamespace")
+}
+
+// TestClusterCuratorPredicateCuratingJobClearedIsAllowedThrough verifies the
+// predicate no longer drops the event where CuratingJob transitions to "" while
+// DesiredCuration is unchanged (the upgrade-completion signal).
+func TestClusterCuratorPredicateCuratingJobClearedIsAllowedThrough(t *testing.T) {
+	pred := newClusterCuratorPredicate()
+
+	oldCurator := getHypershiftUpgradeDoneCurator()
+	oldCurator.Spec.CuratingJob = "curator-job-abc"
+	// Old object's status must match new object's status; the predicate drops
+	// events where Status differs, and this test targets the Spec-only case.
+	newCurator := oldCurator.DeepCopy()
+	newCurator.Spec.CuratingJob = ""
+
+	allowed := pred.Update(event.UpdateEvent{ObjectOld: oldCurator, ObjectNew: newCurator})
+	assert.True(t, allowed, "reconcile should run when CuratingJob clears so curator-crb cleanup can happen")
+}
+
+// TestClusterCuratorPredicateDesiredCurationClearedIsAllowedThrough is a
+// regression check for the earlier install/destroy completion fix, to make sure
+// it still behaves correctly alongside the new CuratingJob change.
+func TestClusterCuratorPredicateDesiredCurationClearedIsAllowedThrough(t *testing.T) {
+	pred := newClusterCuratorPredicate()
+
+	oldCurator := &clustercuratorv1.ClusterCurator{
+		Spec: clustercuratorv1.ClusterCuratorSpec{DesiredCuration: "install", CuratingJob: ""},
+	}
+	newCurator := oldCurator.DeepCopy()
+	newCurator.Spec.DesiredCuration = ""
+
+	allowed := pred.Update(event.UpdateEvent{ObjectOld: oldCurator, ObjectNew: newCurator})
+	assert.True(t, allowed, "reconcile should run when DesiredCuration clears so install/destroy cleanup can happen")
+}
+
+// TestClusterCuratorPredicateStatusOnlyChangeIsDropped is a regression check
+// that unrelated status-only updates are still suppressed.
+func TestClusterCuratorPredicateStatusOnlyChangeIsDropped(t *testing.T) {
+	pred := newClusterCuratorPredicate()
+
+	oldCurator := getHypershiftUpgradeDoneCurator()
+	newCurator := oldCurator.DeepCopy()
+	newCurator.Status.Conditions[0].Message = "a different message"
+
+	allowed := pred.Update(event.UpdateEvent{ObjectOld: oldCurator, ObjectNew: newCurator})
+	assert.False(t, allowed, "status-only changes must still be dropped")
+}

--- a/pkg/jobs/rbac/rbac.go
+++ b/pkg/jobs/rbac/rbac.go
@@ -365,6 +365,20 @@ func CleanupRBAC(kubeset kubernetes.Interface, namespace string) error {
 // CleanupRBACHypershift removes the curator RoleBinding from the Hypershift cluster
 // namespace, and removes the shared curator-crb ClusterRoleBinding's grant if it
 // still belongs to curatorNamespace.
+func CleanupRBACHypershift(kubeset kubernetes.Interface, clusterNamespace string, curatorNamespace string) error {
+	klog.V(2).Info("Cleaning up Hypershift RBAC in namespace " + clusterNamespace)
+
+	if err := kubeset.RbacV1().RoleBindings(clusterNamespace).Delete(
+		context.TODO(), "curator", v1.DeleteOptions{}); err != nil && !k8serrors.IsNotFound(err) {
+		return err
+	}
+	klog.V(0).Info(" Deleted RoleBinding curator in cluster namespace ✓")
+
+	return CleanupCuratorCRBIfOwned(kubeset, curatorNamespace)
+}
+
+// CleanupCuratorCRBIfOwned removes the shared, cluster-wide curator-crb
+// ClusterRoleBinding's grant if it still belongs to curatorNamespace.
 //
 // curator-crb is a cluster-wide singleton with a single subject slot that
 // ApplyRBACHypershift upserts to whichever curatorNamespace most recently ran a
@@ -375,15 +389,12 @@ func CleanupRBAC(kubeset kubernetes.Interface, namespace string) error {
 // the escalation path where a tenant could recreate a ServiceAccount named
 // cluster-installer in its own namespace and silently inherit the binding, since
 // RBAC subjects are matched by name/namespace, not object identity.
-func CleanupRBACHypershift(kubeset kubernetes.Interface, clusterNamespace string, curatorNamespace string) error {
-	klog.V(2).Info("Cleaning up Hypershift RBAC in namespace " + clusterNamespace)
-
-	if err := kubeset.RbacV1().RoleBindings(clusterNamespace).Delete(
-		context.TODO(), "curator", v1.DeleteOptions{}); err != nil && !k8serrors.IsNotFound(err) {
-		return err
-	}
-	klog.V(0).Info(" Deleted RoleBinding curator in cluster namespace ✓")
-
+//
+// This is safe to call even when a new curation for curatorNamespace is about to
+// launch a job immediately after: ApplyRBACHypershift unconditionally re-upserts
+// curator-crb back to curatorNamespace on its next run, so at worst this causes a
+// harmless delete-then-recreate rather than any window of missing access.
+func CleanupCuratorCRBIfOwned(kubeset kubernetes.Interface, curatorNamespace string) error {
 	crb, err := kubeset.RbacV1().ClusterRoleBindings().Get(context.TODO(), "curator-crb", v1.GetOptions{})
 	if k8serrors.IsNotFound(err) {
 		return nil

--- a/pkg/jobs/rbac/rbac_test.go
+++ b/pkg/jobs/rbac/rbac_test.go
@@ -295,6 +295,56 @@ func TestCleanupRBACHypershift(t *testing.T) {
 	assert.Nil(t, err, "err nil when CleanupRBACHypershift called on already-cleaned namespace")
 }
 
+func TestCleanupCuratorCRBIfOwned(t *testing.T) {
+	kubeset := fake.NewSimpleClientset()
+
+	_ = ApplyRBAC(kubeset, ClusterNamespace)
+	err := ApplyRBACHypershift(kubeset, ClusterName, ClusterNamespace)
+	assert.Nil(t, err, "err nil when Hypershift RBAC applied")
+
+	// Simulates the upgrade-completion path: only curator-crb cleanup runs,
+	// independent of CleanupRBAC/CleanupRBACHypershift and the SA/RoleBindings
+	// they own, since desiredCuration never clears to "" for upgrade.
+	err = CleanupCuratorCRBIfOwned(kubeset, ClusterNamespace)
+	assert.Nil(t, err, "err nil when CleanupCuratorCRBIfOwned succeeds")
+
+	_, err = kubeset.RbacV1().ClusterRoleBindings().Get(context.TODO(), "curator-crb", v1.GetOptions{})
+	assert.NotNil(t, err, "curator-crb should be deleted when it still belongs to curatorNamespace")
+
+	t.Log("Verify the SA and namespaced RoleBindings are left untouched (accepted residue)")
+	_, err = kubeset.CoreV1().ServiceAccounts(ClusterNamespace).Get(context.TODO(), clusterInstaller, v1.GetOptions{})
+	assert.Nil(t, err, "SA must not be deleted by CleanupCuratorCRBIfOwned")
+	_, err = kubeset.RbacV1().RoleBindings(ClusterNamespace).Get(context.TODO(), "curator", v1.GetOptions{})
+	assert.Nil(t, err, "curatorNamespace RoleBinding must not be deleted by CleanupCuratorCRBIfOwned")
+	_, err = kubeset.RbacV1().RoleBindings(ClusterName).Get(context.TODO(), "curator", v1.GetOptions{})
+	assert.Nil(t, err, "cluster-namespace RoleBinding must not be deleted by CleanupCuratorCRBIfOwned")
+
+	t.Log("Verify CleanupCuratorCRBIfOwned is idempotent")
+	err = CleanupCuratorCRBIfOwned(kubeset, ClusterNamespace)
+	assert.Nil(t, err, "err nil when curator-crb is already gone")
+}
+
+func TestCleanupCuratorCRBIfOwnedPreservesOtherNamespace(t *testing.T) {
+	kubeset := fake.NewSimpleClientset()
+
+	_ = ApplyRBAC(kubeset, ClusterNamespace)
+	err := ApplyRBACHypershift(kubeset, ClusterName, ClusterNamespace)
+	assert.Nil(t, err, "err nil for first Hypershift cluster")
+
+	otherNamespace := "other-clusters"
+	err = ApplyRBACHypershift(kubeset, "another-cluster", otherNamespace)
+	assert.Nil(t, err, "err nil for second Hypershift cluster from different namespace")
+
+	// ClusterNamespace's upgrade completes after otherNamespace has already taken
+	// over curator-crb; must not revoke otherNamespace's still-active grant.
+	err = CleanupCuratorCRBIfOwned(kubeset, ClusterNamespace)
+	assert.Nil(t, err, "err nil when CleanupCuratorCRBIfOwned succeeds")
+
+	crb, err := kubeset.RbacV1().ClusterRoleBindings().Get(context.TODO(), "curator-crb", v1.GetOptions{})
+	assert.Nil(t, err, "curator-crb must be preserved since it belongs to otherNamespace")
+	assert.Equal(t, otherNamespace, crb.Subjects[0].Namespace, "curator-crb subject namespace must remain otherNamespace")
+}
+
 func TestCleanupRBACHypershiftPreservesCRBOwnedByOtherNamespace(t *testing.T) {
 	kubeset := fake.NewSimpleClientset()
 


### PR DESCRIPTION
PR #606 fixed cluster-wide ClusterRoleBinding/curator-crb to bind a minimal ClusterRole, and added cleanup of the cluster-installer ServiceAccount and namespaced RoleBinding once a curation completes. However, upgrade curations never clear DesiredCuration back to "" (see utils.NeedToUpgrade), and the predicate blocked events where only CuratingJob cleared, so the cleanup path never ran for Hypershift upgrades. This left curator-crb granting cluster-wide managedclusters access indefinitely after an upgrade completed.

- Allow the predicate to pass through when CuratingJob clears, not just when DesiredCuration clears, so Reconcile runs once an upgrade Job finishes.
- Add an independent, ownership-guarded cleanup of curator-crb in Reconcile for Hypershift curators whenever no job is actively running, covering the upgrade completion path.
- Extract the guarded curator-crb deletion from CleanupRBACHypershift into an exported CleanupCuratorCRBIfOwned helper shared by both call sites.

The cluster-installer ServiceAccount and namespaced RoleBinding/curator still persist after an upgrade completes (DesiredCuration remains "upgrade"), matching existing Hive-style residue; this is accepted as lower-severity, namespace-bounded risk since it grants no cluster-wide authority.

https://redhat.atlassian.net/browse/ACM-39828